### PR TITLE
feat: Make `HybridObject` shareable with `shared_from_this`

### DIFF
--- a/package/cpp/jsi/HybridObject.h
+++ b/package/cpp/jsi/HybridObject.h
@@ -33,9 +33,8 @@ public:
    * Get the `std::shared_ptr` instance of this HybridObject.
    * The HybridObject must be managed inside a `shared_ptr` already, otherwise this will fail.
    */
-  template<typename Derived>
-  std::shared_ptr<Derived> shared() {
-      return std::static_pointer_cast<Derived>(shared_from_this());
+  template <typename Derived> std::shared_ptr<Derived> shared() {
+    return std::static_pointer_cast<Derived>(shared_from_this());
   }
 
   /**


### PR DESCRIPTION
Makes `HybridObject<T>` shareable with `shared_from_this`.

```diff
 class HybridObject { 
+  std::shared_ptr<Derived> shared();
 }
```

To pass a shared_ptr:

```cpp
class RendererWrapper: public HybridObject {
public:
  RendererWrapper(std::shared_ptr<EngineWrapper> engineWrapper):
    _engineWrapper(engineWrapper) { }

  int getSomething() {
    // since it returns a ref (&) we assume there is virtually no overhead when calling that.
    Renderer& renderer = _engineWrapper->getRenderer();
    return renderer.getSomething();
  }

protected:
  void loadHybridMethods() override {
    registerHybridMethod("getSomething", & RendererWrapper::getSomething, this);
  }

private:
  std::shared_ptr<EngineWrapper> _engineWrapper;
};

// ...

class EngineWrapper: public HybridObject {
public:
  EngineWrapper() {}

  std::shared_ptr<RendererWrapper> EngineWrapper::getRenderer() {
    // ----------------- HERE is the exciting part -----------------
    std::shared_ptr<EngineWrapper> sharedThis = shared<EngineWrapper>();
    return std::make_shared<RendererWrapper>(sharedThis);
  }

protected:
  void loadHybridMethods() override {
    registerHybridMethod("getRenderer", &EngineWrapper::getRenderer, this);
  }
};
```


> [!CAUTION]
> The `getRenderer()` API on filament's `Engine` is fast as it just returns a reference (virtually no cost), while ours creates a new instance of `RendererWrapper` (and a new jsi::HostObject). So I think it makes sense to cache that in `EngineWrapper` to avoid creating new objects when repeadedly calling `getRenderer()`. get it?