### PR TITLE
feat: Allow User to extend enums

### DIFF
--- a/package/cpp/jsi/EnumMapper.h
+++ b/package/cpp/jsi/EnumMapper.h
@@ -4,57 +4,30 @@
 
 #pragma once
 
-#include "test/TestEnum.h"
-#include <unordered_map>
+#include <stdexcept>
+#include <string>
 
 namespace margelo {
 
-using namespace facebook;
+namespace EnumMapper {
+  // Add these two methods in namespace "EnumMapper" to allow parsing a custom enum:
+  // 1. `static void convertJSUnionToEnum(const std::string& inUnion, Enum* outEnum)`
+  // 2. `static void convertEnumToJSUnion(Enum inEnum, std::string* outUnion)`
 
-static std::runtime_error invalidUnion(const std::string jsUnion) {
-  return std::runtime_error("Cannot convert JS Value to Enum: Invalid Union value passed! (\"" + jsUnion + "\")");
-}
-template <typename Enum> static std::runtime_error invalidEnum(Enum passedEnum) {
-  return std::runtime_error("Cannot convert Enum to JS Value: Invalid Enum passed! (Value #" + std::to_string(passedEnum) +
-                            " does not exist in " + typeid(Enum).name() + ")");
-}
-
-template <typename Enum> struct EnumMapper {
-  static Enum fromJSUnion(const std::string&) {
-    static_assert(always_false<Enum>::value, "This type is not supported by the EnumMapper!");
-    return Enum();
+  static std::runtime_error invalidUnion(const std::string& passedUnion) {
+    return std::runtime_error("Cannot convert JS Value to Enum: Invalid Union value passed! (\"" + std::string(passedUnion) + "\")");
   }
-  static std::string toJSUnion(Enum) {
-    static_assert(always_false<Enum>::value, "This type is not supported by the EnumMapper!");
-    return std::string();
+  static std::runtime_error invalidEnum(int passedEnum) {
+    return std::runtime_error("Cannot convert Enum to JS Value: Invalid Enum passed! (Value #" + std::to_string(passedEnum) + ")");
   }
 
-private:
-  template <typename> struct always_false : std::false_type {};
-};
+  static void convertJSUnionToEnum(const std::string& inUnion, int*) {
+    throw invalidUnion(inUnion);
+  }
 
-template <> struct EnumMapper<TestEnum> {
-public:
-  static constexpr TestEnum fromJSUnion(const std::string& jsUnion) {
-    if (jsUnion == "first")
-      return FIRST;
-    if (jsUnion == "second")
-      return SECOND;
-    if (jsUnion == "third")
-      return THIRD;
-    throw invalidUnion(jsUnion);
+  static void convertEnumToJSUnion(int inEnum, std::string*) {
+    throw invalidEnum(inEnum);
   }
-  static std::string toJSUnion(TestEnum value) {
-    switch (value) {
-      case FIRST:
-        return "first";
-      case SECOND:
-        return "second";
-      case THIRD:
-        return "third";
-    }
-    throw invalidEnum(value);
-  }
-};
+} // namespace EnumMapper
 
 } // namespace margelo

--- a/package/cpp/jsi/JSIConverter.h
+++ b/package/cpp/jsi/JSIConverter.h
@@ -104,11 +104,14 @@ template <typename TInner> struct JSIConverter<std::optional<TInner>> {
 template <typename TEnum> struct JSIConverter<TEnum, std::enable_if_t<std::is_enum<TEnum>::value>> {
   static TEnum fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
     std::string string = arg.asString(runtime).utf8(runtime);
-    return EnumMapper<TEnum>::fromJSUnion(string);
+    TEnum outEnum;
+    EnumMapper::convertJSUnionToEnum(string, &outEnum);
+    return outEnum;
   }
   static jsi::Value toJSI(jsi::Runtime& runtime, TEnum arg) {
-    std::string string = EnumMapper<TEnum>::toJSUnion(arg);
-    return jsi::String::createFromUtf8(runtime, string);
+    std::string outUnion;
+    EnumMapper::convertEnumToJSUnion(arg, &outUnion);
+    return jsi::String::createFromUtf8(runtime, outUnion);
   }
 };
 

--- a/package/cpp/test/TestEnum.h
+++ b/package/cpp/test/TestEnum.h
@@ -10,4 +10,31 @@ namespace margelo {
 
 enum TestEnum { FIRST, SECOND, THIRD };
 
-}
+namespace EnumMapper {
+  static void convertJSUnionToEnum(const std::string& inUnion, TestEnum* outEnum) {
+    if (inUnion == "first")
+      *outEnum = FIRST;
+    else if (inUnion == "second")
+      *outEnum = SECOND;
+    else if (inUnion == "third")
+      *outEnum = THIRD;
+    else
+      throw invalidUnion(inUnion);
+  }
+  static void convertEnumToJSUnion(TestEnum inEnum, std::string* outUnion) {
+    switch (inEnum) {
+      case FIRST:
+        *outUnion = "first";
+        break;
+      case SECOND:
+        *outUnion = "second";
+        break;
+      case THIRD:
+        *outUnion = "third";
+        break;
+      default:
+        throw invalidEnum(inEnum);
+    }
+  }
+} // namespace EnumMapper
+} // namespace margelo


### PR DESCRIPTION
Enum mappers are now a bit different, you declare your enums as usual in C++, but then add the converter functions to the `EnumMapper` namespace:

```cpp
namespace margelo {
 
// 1. Create your C++ enum
enum Backend { METAL, OPEN_GL, VULKAN };

namespace EnumMapper {

  // 2. Add JS Union -> C++ Enum converter for your enum specifically
  static void convertJSUnionToEnum(const std::string& inUnion, Backend* outEnum) {
    if (inUnion == "metal")
      *outEnum = METAL;
    else if (inUnion == "open-gl")
      *outEnum = OPEN_GL;
    else if (inUnion == "vulkan")
      *outEnum = VULKAN;
    else
      throw invalidUnion(inUnion);
  }

  // 3. Add C++ Enum -> JS Union converter for your enum specifically
  static void convertEnumToJSUnion(Backend inEnum, std::string* outUnion) {
    switch (inEnum) {
      case METAL:
        *outUnion = "metal";
        break;
      case OPEN_GL:
        *outUnion = "open-gl";
        break;
      case VULKAN:
        *outUnion = "vulkan";
        break;
      default:
        throw invalidEnum(inEnum);
    }
  }

} // namespace EnumMapper

} // namespace margelo
```