### PR TITLE
feat: Make every hybrid `std::shared_ptr<T>` nullable

### DIFF
--- a/package/cpp/jsi/JSIConverter.h
+++ b/package/cpp/jsi/JSIConverter.h
@@ -82,8 +82,7 @@ template <> struct JSIConverter<bool> {
 };
 
 // std::string <> string
-template <>
-struct JSIConverter<std::string> {
+template <> struct JSIConverter<std::string> {
   static std::string fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
     return arg.asString(runtime).utf8(runtime);
   }
@@ -225,10 +224,18 @@ template <typename T> struct is_shared_ptr_to_host_object<std::shared_ptr<T>> : 
 
 template <typename T> struct JSIConverter<T, std::enable_if_t<is_shared_ptr_to_host_object<T>::value>> {
   static T fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
-    return arg.asObject(runtime).asHostObject<typename T::element_type>(runtime);
+    if (arg.isUndefined() || arg.isNull()) {
+      return nullptr;
+    } else {
+      return arg.asObject(runtime).asHostObject<typename T::element_type>(runtime);
+    }
   }
   static jsi::Value toJSI(jsi::Runtime& runtime, const T& arg) {
-    return jsi::Object::createFromHostObject(runtime, arg);
+    if (arg == nullptr) {
+      return jsi::Value::undefined();
+    } else {
+      return jsi::Object::createFromHostObject(runtime, arg);
+    }
   }
 };
 


### PR DESCRIPTION
Makes every `std::shared_ptr<T>` nullable by default. We now have to treat every std::shared_ptr<T> as nullable in our codebase. 

We still need to think about if this change makes sense.

Before:

```cpp
void test(std::shared_ptr<AnotherHostObject> hostObject) {
  hostObject->sayHello();
}

registerHybridMethod("test", &MyHostObject::test, this);
```

```js
const anotherHostObject = getAnotherHostObject()
myHostObject.test(anotherHostObject) // <-- works
myHostObject.test(undefined) // <-- crashes with "jsi::HostObject cannot be casted" or something
```

After:

```cpp
void test(std::shared_ptr<AnotherHostObject> hostObject) {
  if (hostObject == nullptr) {
    // do something if it is null, maybe throw an error, maybe default behaviour
  } else {
    hostObject->sayHello();
  }
}

registerHybridMethod("test", &MyHostObject::test, this);
```

```js
const anotherHostObject = getAnotherHostObject()
myHostObject.test(anotherHostObject) // <-- works
myHostObject.test(undefined) // <-- works, uses nullable branch in code
```


> [!NOTE]
> This was also possible before by simply using `std::optional<std::shared_ptr<T>>`, so this PR simply changes that shared ptrs are nullable by default.

