### PR TITLE
feat: Create memory-safe C++ `ManagedBuffer`

### DIFF
--- a/package/android/CMakeLists.txt
+++ b/package/android/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(
         # Java JNI
         src/main/cpp/AndroidFilamentProxy.cpp
         src/main/cpp/AndroidSurface.cpp
+        src/main/cpp/AndroidManagedBuffer.cpp
         src/main/cpp/Filament.cpp
         src/main/cpp/JNISharedPtr.cpp
         src/main/cpp/FilamentInstaller.cpp

--- a/package/android/src/main/cpp/AndroidManagedBuffer.h
+++ b/package/android/src/main/cpp/AndroidManagedBuffer.h
@@ -1,0 +1,37 @@
+//
+// Created by Marc Rousavy on 05.03.24.
+//
+
+#pragma once
+
+#include "ManagedBuffer.h"
+#include <fbjni/ByteBuffer.h>
+#include <fbjni/fbjni.h>
+
+namespace margelo {
+
+using namespace facebook;
+
+class AndroidManagedBuffer : public ManagedBuffer {
+public:
+  explicit AndroidManagedBuffer(const jni::alias_ref<jni::JByteBuffer>& buffer) : _buffer(jni::make_global(buffer)) {
+    _buffer->rewind();
+  }
+
+  ~AndroidManagedBuffer() {
+    jni::ThreadScope::WithClassLoader([&] { _buffer.reset(); });
+  }
+
+  const uint8_t* getData() const override {
+    return _buffer->getDirectBytes();
+  }
+
+  size_t getSize() const override {
+    return _buffer->getDirectSize();
+  }
+
+private:
+  jni::global_ref<jni::JByteBuffer> _buffer;
+};
+
+} // namespace margelo

--- a/package/android/src/main/cpp/java-bindings/JFilamentProxy.cpp
+++ b/package/android/src/main/cpp/java-bindings/JFilamentProxy.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "JFilamentProxy.h"
+#include "AndroidManagedBuffer.h"
 #include "JChoreographer.h"
 #include "JFilamentView.h"
 #include "JNISharedPtr.h"
@@ -23,9 +24,9 @@ JFilamentProxy::~JFilamentProxy() {
 
 std::shared_ptr<FilamentBuffer> JFilamentProxy::getAssetByteBuffer(const std::string& path) {
   static const auto method = javaClassLocal()->getMethod<jni::alias_ref<jni::JByteBuffer>(jni::alias_ref<jstring>)>("getAssetByteBuffer");
-  jni::local_ref<jni::JByteBuffer> localRef = method(_javaPart, jni::make_jstring(path));
-  jni::global_ref<jni::JByteBuffer> globalRef = jni::make_global(localRef);
-  return std::make_shared<FilamentBuffer>(globalRef->getDirectBytes(), globalRef->getDirectSize());
+  jni::local_ref<jni::JByteBuffer> buffer = method(_javaPart, jni::make_jstring(path));
+  auto managedBuffer = std::make_shared<AndroidManagedBuffer>(buffer);
+  return std::make_shared<FilamentBuffer>(managedBuffer);
 }
 
 std::shared_ptr<FilamentView> JFilamentProxy::findFilamentView(int id) {

--- a/package/cpp/FilamentBuffer.h
+++ b/package/cpp/FilamentBuffer.h
@@ -1,26 +1,22 @@
 #pragma once
 
+#include "ManagedBuffer.h"
 #include "jsi/HybridObject.h"
-#include <cstdint>
-#include <stddef.h>
 
 namespace margelo {
 
 class FilamentBuffer : public HybridObject {
 public:
-  explicit FilamentBuffer(uint8_t* data, size_t size) : _data(data), _size(size) {}
+  explicit FilamentBuffer(const std::shared_ptr<ManagedBuffer>& buffer) : _buffer(std::move(buffer)) {}
 
   void loadHybridMethods() override {}
 
-  uint8_t* getData() const {
-    return _data;
-  }
-  size_t getSize() const {
-    return _size;
+  const std::shared_ptr<ManagedBuffer>& getBuffer() {
+    return _buffer;
   }
 
 private:
-  uint8_t* _data;
-  size_t _size;
+  std::shared_ptr<ManagedBuffer> _buffer;
 };
+
 } // namespace margelo

--- a/package/cpp/ManagedBuffer.h
+++ b/package/cpp/ManagedBuffer.h
@@ -1,0 +1,19 @@
+//
+// Created by Marc Rousavy on 05.03.24.
+//
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace margelo {
+
+class ManagedBuffer {
+public:
+  virtual ~ManagedBuffer() = 0;
+  virtual const uint8_t* getData() const = 0;
+  virtual size_t getSize() const = 0;
+};
+
+} // namespace margelo

--- a/package/cpp/core/EngineWrapper.cpp
+++ b/package/cpp/core/EngineWrapper.cpp
@@ -34,14 +34,16 @@ EngineWrapper::EngineWrapper(std::shared_ptr<Choreographer> choreographer) {
   // TODO: make the enum for the backend for the engine configurable
   _engine = References<Engine>::adoptRef(Engine::create(), [](Engine* engine) { Engine::destroy(&engine); });
 
-  gltfio::MaterialProvider* _materialProviderPtr = gltfio::createUbershaderProvider(_engine.get(), UBERARCHIVE_DEFAULT_DATA, UBERARCHIVE_DEFAULT_SIZE);
+  gltfio::MaterialProvider* _materialProviderPtr =
+      gltfio::createUbershaderProvider(_engine.get(), UBERARCHIVE_DEFAULT_DATA, UBERARCHIVE_DEFAULT_SIZE);
   _materialProvider = References<gltfio::MaterialProvider>::adoptEngineRef(
       _engine, _materialProviderPtr, [](const std::shared_ptr<Engine>& engine, gltfio::MaterialProvider* provider) {
         provider->destroyMaterials();
         delete provider;
       });
 
-  gltfio::AssetLoader* assetLoaderPtr = gltfio::AssetLoader::create(filament::gltfio::AssetConfiguration{.engine = _engine.get(), .materials = _materialProvider.get()});
+  gltfio::AssetLoader* assetLoaderPtr =
+      gltfio::AssetLoader::create(filament::gltfio::AssetConfiguration{.engine = _engine.get(), .materials = _materialProvider.get()});
   _assetLoader = References<gltfio::AssetLoader>::adoptEngineRef(
       _engine, assetLoaderPtr, [](const std::shared_ptr<Engine>& engine, gltfio::AssetLoader* assetLoader) {
         auto* ncm = assetLoader->getNames();
@@ -49,7 +51,8 @@ EngineWrapper::EngineWrapper(std::shared_ptr<Choreographer> choreographer) {
         gltfio::AssetLoader::destroy(&assetLoader);
       });
 
-  gltfio::ResourceLoader* resourceLoaderPtr = new filament::gltfio::ResourceLoader({.engine = _engine.get(), .normalizeSkinningWeights = true});
+  gltfio::ResourceLoader* resourceLoaderPtr =
+      new filament::gltfio::ResourceLoader({.engine = _engine.get(), .normalizeSkinningWeights = true});
   // Add texture providers to the resource loader
   auto stbProvider = filament::gltfio::createStbProvider(_engine.get());
   auto ktx2Provider = filament::gltfio::createKtx2Provider(_engine.get());
@@ -57,7 +60,8 @@ EngineWrapper::EngineWrapper(std::shared_ptr<Choreographer> choreographer) {
   resourceLoaderPtr->addTextureProvider("image/png", stbProvider);
   resourceLoaderPtr->addTextureProvider("image/ktx2", ktx2Provider);
   _resourceLoader = References<gltfio::ResourceLoader>::adoptEngineRef(
-      _engine, resourceLoaderPtr, [stbProvider, ktx2Provider](const std::shared_ptr<Engine>& engine, gltfio::ResourceLoader* resourceLoader) {
+      _engine, resourceLoaderPtr,
+      [stbProvider, ktx2Provider](const std::shared_ptr<Engine>& engine, gltfio::ResourceLoader* resourceLoader) {
         delete stbProvider;
         delete ktx2Provider;
         delete resourceLoader;

--- a/package/cpp/jsi/JSIConverter.h
+++ b/package/cpp/jsi/JSIConverter.h
@@ -82,8 +82,7 @@ template <> struct JSIConverter<bool> {
 };
 
 // std::string <> string
-template <>
-struct JSIConverter<std::string> {
+template <> struct JSIConverter<std::string> {
   static std::string fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
     return arg.asString(runtime).utf8(runtime);
   }

--- a/package/example/ios/FilamentExample.xcodeproj/project.pbxproj
+++ b/package/example/ios/FilamentExample.xcodeproj/project.pbxproj
@@ -8,14 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* FilamentExampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* FilamentExampleTests.m */; };
+		0B65F1CE0E1D4DBB9E25D0BD /* default_env_ibl.ktx in Resources */ = {isa = PBXBuildFile; fileRef = 7A69823713B34897AF31CAF0 /* default_env_ibl.ktx */; };
 		0C80B921A6F3F58F76C31292 /* libPods-FilamentExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DCACB8F33CDC322A6C60F78 /* libPods-FilamentExample.a */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		59249653BB174593BEDB9F3D /* pengu.glb in Resources */ = {isa = PBXBuildFile; fileRef = 3E2439B417DA497E83EB1F05 /* pengu.glb */; };
 		7699B88040F8A987B510C191 /* libPods-FilamentExample-FilamentExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-FilamentExample-FilamentExampleTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		0B65F1CE0E1D4DBB9E25D0BD /* default_env_ibl.ktx in Resources */ = {isa = PBXBuildFile; fileRef = 7A69823713B34897AF31CAF0 /* default_env_ibl.ktx */; };
-		59249653BB174593BEDB9F3D /* pengu.glb in Resources */ = {isa = PBXBuildFile; fileRef = 3E2439B417DA497E83EB1F05 /* pengu.glb */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,14 +40,14 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = FilamentExample/main.m; sourceTree = "<group>"; };
 		19F6CBCC0A4E27FBF8BF4A61 /* libPods-FilamentExample-FilamentExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FilamentExample-FilamentExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B4392A12AC88292D35C810B /* Pods-FilamentExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FilamentExample.debug.xcconfig"; path = "Target Support Files/Pods-FilamentExample/Pods-FilamentExample.debug.xcconfig"; sourceTree = "<group>"; };
+		3E2439B417DA497E83EB1F05 /* pengu.glb */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = pengu.glb; path = ../assets/pengu.glb; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-FilamentExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FilamentExample.release.xcconfig"; path = "Target Support Files/Pods-FilamentExample/Pods-FilamentExample.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-FilamentExample-FilamentExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FilamentExample-FilamentExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-FilamentExample-FilamentExampleTests/Pods-FilamentExample-FilamentExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-FilamentExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FilamentExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7A69823713B34897AF31CAF0 /* default_env_ibl.ktx */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = default_env_ibl.ktx; path = ../assets/default_env_ibl.ktx; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = FilamentExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		89C6BE57DB24E9ADA2F236DE /* Pods-FilamentExample-FilamentExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FilamentExample-FilamentExampleTests.release.xcconfig"; path = "Target Support Files/Pods-FilamentExample-FilamentExampleTests/Pods-FilamentExample-FilamentExampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
-		7A69823713B34897AF31CAF0 /* default_env_ibl.ktx */ = {isa = PBXFileReference; name = "default_env_ibl.ktx"; path = "../assets/default_env_ibl.ktx"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		3E2439B417DA497E83EB1F05 /* pengu.glb */ = {isa = PBXFileReference; name = "pengu.glb"; path = "../assets/pengu.glb"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -142,6 +142,16 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		995DFB4F30584326AD631A9F /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				7A69823713B34897AF31CAF0 /* default_env_ibl.ktx */,
+				3E2439B417DA497E83EB1F05 /* pengu.glb */,
+			);
+			name = Resources;
+			path = "";
+			sourceTree = "<group>";
+		};
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -152,16 +162,6 @@
 			);
 			path = Pods;
 			sourceTree = "<group>";
-		};
-		995DFB4F30584326AD631A9F /* Resources */ = {
-			isa = "PBXGroup";
-			children = (
-				7A69823713B34897AF31CAF0 /* default_env_ibl.ktx */,
-				3E2439B417DA497E83EB1F05 /* pengu.glb */,
-			);
-			name = Resources;
-			sourceTree = "<group>";
-			path = "";
 		};
 /* End PBXGroup section */
 
@@ -599,7 +599,10 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -667,7 +670,10 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/package/ios/src/AppleFilamentProxy.mm
+++ b/package/ios/src/AppleFilamentProxy.mm
@@ -8,6 +8,7 @@
 #import "AppleFilamentProxy.h"
 #import "AppleChoreographer.h"
 #import "AppleFilamentView.h"
+#import "AppleManagedBuffer.h"
 #import "FilamentMetalView.h"
 #import "FilamentView.h"
 #import <Foundation/Foundation.h>
@@ -48,9 +49,8 @@ std::shared_ptr<FilamentBuffer> AppleFilamentProxy::getAssetByteBuffer(std::stri
     throw std::runtime_error("File not found or could not be read");
   }
 
-  u_int8_t* data = (u_int8_t*)[bufferData bytes];
-  size_t size = [bufferData length];
-  return std::make_shared<FilamentBuffer>(data, size);
+  auto managedBuffer = std::make_shared<AppleManagedBuffer>(bufferData);
+  return std::make_shared<FilamentBuffer>(managedBuffer);
 }
 
 jsi::Runtime& AppleFilamentProxy::getRuntime() {

--- a/package/ios/src/AppleManagedBuffer.h
+++ b/package/ios/src/AppleManagedBuffer.h
@@ -1,0 +1,31 @@
+//
+//  AppleManagedBuffer.h
+//  react-native-filament
+//
+//  Created by Marc Rousavy on 05.03.24.
+//
+
+#pragma once
+
+#include "ManagedBuffer.h"
+#include <Foundation/Foundation.h>
+
+namespace margelo {
+
+class AppleManagedBuffer : public ManagedBuffer {
+public:
+  explicit AppleManagedBuffer(NSData* data) : _data(data) {}
+
+  const uint8_t* getData() const override {
+    return static_cast<const uint8_t*>(_data.bytes);
+  }
+
+  size_t getSize() const override {
+    return _data.length;
+  }
+
+private:
+  NSData* _data;
+};
+
+} // namespace margelo


### PR DESCRIPTION
Creates a new memory-"safe" buffer to represent raw byte buffers (`uint8_t*`).

The type `ManagedBuffer` is platform-specific:
- On Android it holds a strong reference to a `jni::global_ref<JByteBuffer>`
- On iOS it holds a strong reference to a `NSData*`

It contains two methods:

- `const uint8_t* getData()`: Returns **read-only** access to the data
- `size_t getSize()`: Returns the size of the data