### PR TITLE
fix(ios): fix crash when reloading app

### DIFF
--- a/package/cpp/core/EngineWrapper.cpp
+++ b/package/cpp/core/EngineWrapper.cpp
@@ -92,10 +92,6 @@ EngineWrapper::EngineWrapper(std::shared_ptr<Choreographer> choreographer, std::
   _choreographer = choreographer;
 }
 
-EngineWrapper::~EngineWrapper() {
-  destroySurface();
-}
-
 void EngineWrapper::loadHybridMethods() {
   registerHybridMethod("setSurfaceProvider", &EngineWrapper::setSurfaceProvider, this);
   registerHybridMethod("setRenderCallback", &EngineWrapper::setRenderCallback, this);
@@ -129,8 +125,7 @@ void EngineWrapper::setSurfaceProvider(std::shared_ptr<SurfaceProvider> surfaceP
 
   auto queue = _jsDispatchQueue;
   std::weak_ptr<EngineWrapper> weakSelf = shared<EngineWrapper>();
-  SurfaceProvider::Callback callback{// NOTE: This callback will only be invoked on android
-                                     .onSurfaceCreated =
+  SurfaceProvider::Callback callback{.onSurfaceCreated =
                                          [queue, weakSelf](std::shared_ptr<Surface> surface) {
                                            queue->runOnJS([=]() {
                                              auto sharedThis = weakSelf.lock();
@@ -151,7 +146,6 @@ void EngineWrapper::setSurfaceProvider(std::shared_ptr<SurfaceProvider> surfaceP
                                              }
                                            });
                                          },
-                                     // NOTE: This callback will only be invoked on android
                                      .onSurfaceDestroyed =
                                          [queue, weakSelf](std::shared_ptr<Surface> surface) {
                                            // TODO(Marc): When compiling in debug mode we get an assertion error here, because we are

--- a/package/cpp/core/EngineWrapper.h
+++ b/package/cpp/core/EngineWrapper.h
@@ -53,7 +53,6 @@ using RenderCallback = std::function<void(double, double, double)>;
 class EngineWrapper : public HybridObject {
 public:
   explicit EngineWrapper(std::shared_ptr<Choreographer> choreographer, std::shared_ptr<JSDispatchQueue> jsDispatchQueue);
-  ~EngineWrapper() override;
 
   void setSurfaceProvider(std::shared_ptr<SurfaceProvider> surfaceProvider);
 


### PR DESCRIPTION
**Changes:**

- Important: delete resource loader first, then delete texture provider. Otherwise there might be a crash
- Release surface resources (such as render callback, swap chain, choreographer callback) in destructor (Handles cleaning surface on iOS)
- In surface callbacks only use weak pointers to this to avoid engine being strong referenced by them