### PR TITLE
fix: update resources while rendering

### DIFF
--- a/package/cpp/core/EngineWrapper.cpp
+++ b/package/cpp/core/EngineWrapper.cpp
@@ -222,6 +222,8 @@ void EngineWrapper::renderFrame(double timestamp) {
     return;
   }
 
+  _resourceLoader->asyncUpdateLoad();
+
   if (_startTime == 0) {
     _startTime = timestamp;
   }


### PR DESCRIPTION
[In this PR](https://github.com/margelo/react-native-filament/pull/36) I removed the `_resourceLoader->asyncUpdateLoad();` statement. It might have introduced an issue where resources only load partially