### PR TITLE
fix: fix occasional crash in debug

### DIFF
--- a/package/cpp/jsi/HybridObject.cpp
+++ b/package/cpp/jsi/HybridObject.cpp
@@ -10,8 +10,10 @@ namespace margelo {
 
 #if DEBUG
 static std::unordered_map<const char*, int> _instanceIds;
+static std::mutex _mutex;
 
 static int getId(const char* name) {
+  std::unique_lock lock(_mutex);
   if (_instanceIds.find(name) == _instanceIds.end()) {
     _instanceIds.insert({name, 1});
   }


### PR DESCRIPTION
Happened when we tried to insert two HybridObjects in the debug map with the same name at the same time, which can happen as they are created from separate threads.