### PR TITLE
feat: Create `PointerHolder` as a new base class for pointers

### DIFF
--- a/package/src/types/PointerHolder.ts
+++ b/package/src/types/PointerHolder.ts
@@ -28,4 +28,11 @@ export interface PointerHolder {
    * object will throw an Error.
    */
   release(): void
+  /**
+   * Get if the refernce to the native pointer is still valid and strong.
+   *
+   * If this is `false`, this object has been manually released with
+   * {@linkcode release()} and all other methods on this object will throw an Error.
+   */
+  readonly isValid: boolean
 }


### PR DESCRIPTION
Create `PointerHolder` (a `HybridObject` itself) which should be a new base-class for any pointer holders.

The object has a `release()` method, which is exposed to JS to manually release it's underlying pointer to free the memory.

All our wrapper objects (e.g. `SceneWrapper`) should derive from this and should be refactored to only hold a single pointer.