### PR TITLE
Revert "perf: wrap render callback in commit transaction"

### DIFF
--- a/package/cpp/core/EngineImpl.cpp
+++ b/package/cpp/core/EngineImpl.cpp
@@ -31,8 +31,7 @@ namespace margelo {
 
 EngineImpl::EngineImpl(std::shared_ptr<Choreographer> choreographer, std::shared_ptr<Dispatcher> rendererDispatcher,
                        std::shared_ptr<Engine> engine)
-    : _engine(engine), _rendererDispatcher(rendererDispatcher), _choreographer(choreographer),
-      _transformManagerRef(engine->getTransformManager()) {
+    : _engine(engine), _rendererDispatcher(rendererDispatcher), _choreographer(choreographer) {
 
   gltfio::MaterialProvider* _materialProviderPtr =
       gltfio::createUbershaderProvider(engine.get(), UBERARCHIVE_DEFAULT_DATA, UBERARCHIVE_DEFAULT_SIZE);
@@ -237,9 +236,7 @@ void EngineImpl::renderFrame(double timestamp) {
     const auto& renderCallback = _renderCallback.value();
     // Call JS callback with scene information
     double passedSeconds = (timestamp - _startTime) / 1e9;
-    _transformManagerRef.openLocalTransformTransaction();
     renderCallback(timestamp, _startTime, passedSeconds);
-    _transformManagerRef.commitLocalTransformTransaction();
   }
 
   std::shared_ptr<SwapChain> swapChain = _swapChain->getSwapChain();
@@ -424,8 +421,7 @@ std::shared_ptr<ManipulatorWrapper> EngineImpl::createCameraManipulator(int widt
 }
 
 std::shared_ptr<TransformManagerWrapper> EngineImpl::createTransformManager() {
-  // TODO: Don't pass the ref here, but create an implementation that the wrapper holds that will hold a ref to the engine!
-  return std::make_shared<TransformManagerWrapper>(_transformManagerRef);
+  return std::make_shared<TransformManagerWrapper>(_engine->getTransformManager());
 }
 
 /**

--- a/package/cpp/core/EngineImpl.h
+++ b/package/cpp/core/EngineImpl.h
@@ -117,7 +117,6 @@ private:
   std::shared_ptr<Camera> _camera;
   std::shared_ptr<ManipulatorWrapper> _cameraManipulator;
   std::shared_ptr<TransformManagerWrapper> _transformManager;
-  TransformManager& _transformManagerRef; // This is guaranteed to be valid as long as the engine lives
 
 private:
   std::shared_ptr<Renderer> createRenderer();


### PR DESCRIPTION
Reverts margelo/react-native-filament#122

It seems to have caused a crash on some devices. All we got is this trace:

```
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 25589 >>> com.slay.pengu <<<
backtrace:
  #00  pc 0x00000000005058f4  /data/app/~~RgCeQpqzJLGsBG4AUh2ndg==/com.slay.pengu-UHffnoiH8DsCBnTnrTIu4w==/split_config.arm64_v8a.apk!libRNFilament.so (filament::FTransformManager::openLocalTransformTransaction()) (BuildId: efecfba0bd47ce2f6a45d13bf31bd172e9fd25ee)
```

No one was able to reproduce it, but we felt its better to revert