### PR TITLE
fix: fix deadlock when surface gets destroyed

### DIFF
--- a/package/cpp/core/EngineImpl.h
+++ b/package/cpp/core/EngineImpl.h
@@ -107,7 +107,7 @@ private:
 private:
   // Internals we create, but share the access with the user
   std::shared_ptr<Renderer> _renderer;
-  std::shared_ptr<SwapChainWrapper> _swapChain;
+  std::shared_ptr<SwapChain> _swapChain;
   std::shared_ptr<Scene> _scene;
   std::shared_ptr<View> _view;
   std::shared_ptr<Camera> _camera;
@@ -115,7 +115,7 @@ private:
 
 private:
   std::shared_ptr<Renderer> createRenderer();
-  std::shared_ptr<SwapChainWrapper> createSwapChain(std::shared_ptr<Surface> surface);
+  std::shared_ptr<SwapChain> createSwapChain(std::shared_ptr<Surface> surface);
   std::shared_ptr<Scene> createScene();
   std::shared_ptr<View> createView();
   std::shared_ptr<Camera> createCamera();
@@ -123,9 +123,6 @@ private:
 
 public:
   // Getters for shared objects
-  std::shared_ptr<SwapChainWrapper> getSwapChain() {
-    return _swapChain;
-  }
   std::shared_ptr<SceneWrapper> getScene() {
     return std::make_shared<SceneWrapper>(_scene);
   }

--- a/package/example/src/WorkletExample.tsx
+++ b/package/example/src/WorkletExample.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useSharedValue } from 'react-native-worklets-core'
-import { Button, Platform, SafeAreaView, StyleSheet } from 'react-native'
+import { Button, Platform, SafeAreaView, StyleSheet, View } from 'react-native'
 import {
   DynamicResolutionOptions,
   Filament,
@@ -115,10 +115,26 @@ const dynamicResolutionOptions: DynamicResolutionOptions = {
 }
 
 export function WorkletExample() {
+  const [showView, setShowView] = React.useState(true)
+
   return (
-    <FilamentProvider dynamicResolutionOptions={dynamicResolutionOptions}>
-      <Renderer />
-    </FilamentProvider>
+    <View style={styles.container}>
+      {showView ? (
+        <FilamentProvider dynamicResolutionOptions={dynamicResolutionOptions}>
+          <Renderer />
+        </FilamentProvider>
+      ) : (
+        <View style={styles.container} />
+      )}
+      <Button
+        title="Toggle view"
+        onPress={() => {
+          setInterval(() => {
+            setShowView((prev) => !prev)
+          }, 195)
+        }}
+      />
+    </View>
   )
 }
 


### PR DESCRIPTION
There was an ANR on android when the surface got destroyed:

```
  #00  pc 0x00000000000911c0  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+32)
  #01  pc 0x0000000000095f20  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex(void volatile*, bool, int, bool, timespec const*)+148)
Diese native Synchronisierungsroutine blockiert den Hauptthread und verursacht einen ANR-Fehler. Weitere Informationen
  #02  pc 0x00000000000fe4bc  /apex/com.android.runtime/lib64/bionic/libc.so (NonPI::MutexLockWithTimeout(pthread_mutex_internal_t*, bool, timespec const*)+392)
  #03  pc 0x00000000000c5d7c  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/split_config.arm64_v8a.apk!libc++_shared.so (std::__ndk1::mutex::lock()+12) (BuildId: a59088f9640cd272bc9542d94dc84a0c88afd558)
  #04  pc 0x0000000000486474  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/split_config.arm64_v8a.apk!libRNFilament.so (margelo::ListenerManager<std::__ndk1::function<void (double)>>::add(std::__ndk1::function<void (double)>)::'lambda'()::operator()() const+84) (BuildId: 08b70b55ba1379598f44a3ad4e2d333d07ee4d85)
  #05  pc 0x0000000000486368  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/split_config.arm64_v8a.apk!libRNFilament.so (std::__ndk1::__function::__func<margelo::ListenerManager<std::__ndk1::function<void (double)>>::add(std::__ndk1::function<void (double)>)::'lambda'(), std::__ndk1::allocator<margelo::ListenerManager<std::__ndk1::function<void (double)>>::add(std::__ndk1::function<void (double)>)::'lambda'()>, void ()>::operator()()+32) (BuildId: 08b70b55ba1379598f44a3ad4e2d333d07ee4d85)
  #06  pc 0x0000000000486b1c  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/split_config.arm64_v8a.apk!libRNFilament.so (margelo::Listener::remove()+56) (BuildId: 08b70b55ba1379598f44a3ad4e2d333d07ee4d85)
  #07  pc 0x000000000049b590  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/split_config.arm64_v8a.apk!libRNFilament.so (margelo::EngineImpl::destroySurface()+196) (BuildId: 08b70b55ba1379598f44a3ad4e2d333d07ee4d85)
  #08  pc 0x00000000004a3da8  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/split_config.arm64_v8a.apk!libRNFilament.so (std::__ndk1::__function::__func<margelo::EngineImpl::setSurfaceProvider(std::__ndk1::shared_ptr<margelo::SurfaceProvider>)::$_5, std::__ndk1::allocator<margelo::EngineImpl::setSurfaceProvider(std::__ndk1::shared_ptr<margelo::SurfaceProvider>)::$_5>, void (std::__ndk1::shared_ptr<margelo::Surface>)>::operator()(std::__ndk1::shared_ptr<margelo::Surface>&&)+4096) (BuildId: 08b70b55ba1379598f44a3ad4e2d333d07ee4d85)
  #09  pc 0x0000000000485b24  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/split_config.arm64_v8a.apk!libRNFilament.so (std::__ndk1::__function::__func<margelo::SurfaceProvider::onSurfaceDestroyed(std::__ndk1::shared_ptr<margelo::Surface>)::$_2, std::__ndk1::allocator<margelo::SurfaceProvider::onSurfaceDestroyed(std::__ndk1::shared_ptr<margelo::Surface>)::$_2>, void (margelo::SurfaceProvider::Callback const&)>::operator()(margelo::SurfaceProvider::Callback const&)+4096) (BuildId: 08b70b55ba1379598f44a3ad4e2d333d07ee4d85)
  #10  pc 0x0000000000483fec  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/split_config.arm64_v8a.apk!libRNFilament.so (margelo::SurfaceProvider::onSurfaceDestroyed(std::__ndk1::shared_ptr<margelo::Surface>)+272) (BuildId: 08b70b55ba1379598f44a3ad4e2d333d07ee4d85)
  #11  pc 0x0000000000516058  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/split_config.arm64_v8a.apk!libRNFilament.so (margelo::JSurfaceProvider::onSurfaceDestroyed(facebook::jni::alias_ref<_jobject*>)+76) (BuildId: 08b70b55ba1379598f44a3ad4e2d333d07ee4d85)
  #12  pc 0x0000000000516adc  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/split_config.arm64_v8a.apk!libRNFilament.so (facebook::jni::detail::MethodWrapper<void (margelo::JSurfaceProvider::*)(facebook::jni::alias_ref<_jobject*>), &margelo::JSurfaceProvider::onSurfaceDestroyed(facebook::jni::alias_ref<_jobject*>), margelo::JSurfaceProvider, void, facebook::jni::alias_ref<_jobject*>>::dispatch(facebook::jni::alias_ref<facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<margelo::JSurfaceProvider, facebook::jni::detail::BaseHybridClass>::JavaPart, facebook::jni::JObject, void>::_javaobject*>, facebook::jni::alias_ref<_jobject*>&&)+72) (BuildId: 08b70b55ba1379598f44a3ad4e2d333d07ee4d85)
  #13  pc 0x0000000000516708  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/split_config.arm64_v8a.apk!libRNFilament.so (facebook::jni::detail::FunctionWrapper<void (*)(facebook::jni::alias_ref<facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<margelo::JSurfaceProvider, facebook::jni::detail::BaseHybridClass>::JavaPart, facebook::jni::JObject, void>::_javaobject*>, facebook::jni::alias_ref<_jobject*>&&), facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<margelo::JSurfaceProvider, facebook::jni::detail::BaseHybridClass>::JavaPart, facebook::jni::JObject, void>::_javaobject*, void, facebook::jni::alias_ref<_jobject*>>::call(_JNIEnv*, _jobject*, _jobject*, void (*)(facebook::jni::alias_ref<facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<margelo::JSurfaceProvider, facebook::jni::detail::BaseHybridClass>::JavaPart, facebook::jni::JObject, void>::_javaobject*>, facebook::jni::alias_ref<_jobject*>&&))+72) (BuildId: 08b70b55ba1379598f44a3ad4e2d333d07ee4d85)
  #14  pc 0x0000000000515a7c  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/split_config.arm64_v8a.apk!libRNFilament.so (facebook::jni::detail::MethodWrapper<void (margelo::JSurfaceProvider::*)(facebook::jni::alias_ref<_jobject*>), &margelo::JSurfaceProvider::onSurfaceDestroyed(facebook::jni::alias_ref<_jobject*>), margelo::JSurfaceProvider, void, facebook::jni::alias_ref<_jobject*>>::call(_JNIEnv*, _jobject*, _jobject*)+36) (BuildId: 08b70b55ba1379598f44a3ad4e2d333d07ee4d85)
  #15  pc 0x000000000051ae70  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/oat/arm64/base.odex (art_jni_trampoline+128)
  #16  pc 0x00000000005b98b0  /apex/com.android.art/lib64/libart.so (nterp_helper+4016)
  #17  pc 0x00000000005f2ccc  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/base.apk (com.margelo.filament.FilamentView.onSurfaceTextureDestroyed+8)
  #18  pc 0x0000000000c52308  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.TextureView.releaseSurfaceTexture+88)
  #19  pc 0x0000000000c52e18  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.TextureView.onDetachedFromWindowInternal+200)
  #20  pc 0x0000000000bbdd5c  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.View.dispatchDetachedFromWindow+220)
  #21  pc 0x0000000000c59684  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.ViewGroup.dispatchDetachedFromWindow+212)
  #22  pc 0x0000000000c59684  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.ViewGroup.dispatchDetachedFromWindow+212)
  #23  pc 0x0000000000c59684  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.ViewGroup.dispatchDetachedFromWindow+212)
  #24  pc 0x0000000000c59684  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.ViewGroup.dispatchDetachedFromWindow+212)
  #25  pc 0x0000000000c59684  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.ViewGroup.dispatchDetachedFromWindow+212)
  #26  pc 0x0000000000c59684  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.ViewGroup.dispatchDetachedFromWindow+212)
  #27  pc 0x0000000000c59684  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.ViewGroup.dispatchDetachedFromWindow+212)
  #28  pc 0x0000000000c5d3f8  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.ViewGroup.endViewTransition+216)
  #29  pc 0x000000000060af74  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/oat/arm64/base.odex (com.swmansion.rnscreens.ScreenStack.endViewTransition+116)
  #30  pc 0x000000000090c87c  /data/app/~~90SImWmEHSKxPcFUMcA5Qg==/com.slay.pengu-p37SZgJjDz10i1Fn2Sfgzg==/oat/arm64/base.odex (androidx.fragment.app.DefaultSpecialEffectsController$4$1.run+60)
  #31  pc 0x00000000009b4de4  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.os.Handler.dispatchMessage+68)
  #32  pc 0x00000000009b8894  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.os.Looper.loopOnce+980)
  #33  pc 0x00000000009b8424  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.os.Looper.loop+916)
  #34  pc 0x0000000000742340  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.app.ActivityThread.main+2128)
  #35  pc 0x000000000033b680  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+640)
  #36  pc 0x000000000037cb18  /apex/com.android.art/lib64/libart.so (_jobject* art::InvokeMethod<(art::PointerSize)8>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jobject*, _jobject*, unsigned long)+1556)
  #37  pc 0x000000000037c4f4  /apex/com.android.art/lib64/libart.so (art::Method_invoke(_JNIEnv*, _jobject*, _jobject*, _jobjectArray*) (.__uniq.165753521025965369065708152063621506277)+32)
  #38  pc 0x0000000000343038  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (art_jni_trampoline+120)
  #39  pc 0x0000000000cf0714  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run+116)
  #40  pc 0x0000000000cfb594  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (com.android.internal.os.ZygoteInit.main+3460)
  #41  pc 0x000000000033b680  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+640)
  #42  pc 0x00000000004e2a90  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeWithVarArgs<_jmethodID*>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jmethodID*, std::__va_list)+728)
  #43  pc 0x000000000057aa68  /apex/com.android.art/lib64/libart.so (art::JNI<true>::CallStaticVoidMethodV(_JNIEnv*, _jclass*, _jmethodID*, std::__va_list)+156)
  #44  pc 0x00000000000e3be8  /system/lib64/libandroid_runtime.so (_JNIEnv::CallStaticVoidMethod(_jclass*, _jmethodID*, ...)+108)
  #45  pc 0x00000000000f05bc  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::start(char const*, android::Vector<android::String8> const&, bool)+856)
  #46  pc 0x0000000000002558  /system/bin/app_process64 (main+1280)
  #47  pc 0x000000000008d7c8  /apex/com.android.runtime/lib64/bionic/libc.so (__libc_init+108)
```

The main issue was that we were locking the mutex in EngineImpl on calling `destroySurface`. We then called `_swapChain = nullptr`, which caused the deleter function of the swap chain pointer to be called.
We then got a deadlock when calling `dispatcher->runAsync`.
Thats because in parallel on the dispatcher thread we were calling some other deleter function which also acquired a lock on the `EngineImpl`s mutex.
Now we had a deadlock because two threads were holding deadlocks the other thread was waiting for to be released.

I now moved the locking to the destroying of the surface where we really need it.