### PR TITLE
fix: fix deadlock on surface destroyed

### DIFF
--- a/package/cpp/core/EngineImpl.cpp
+++ b/package/cpp/core/EngineImpl.cpp
@@ -84,15 +84,6 @@ EngineImpl::EngineImpl(std::shared_ptr<Choreographer> choreographer, std::shared
   _view->setCamera(_camera.get());
 }
 
-EngineImpl::~EngineImpl() {
-  if (_choreographer) {
-    // It can happen that the onSurfaceDestroyed callback wasn't called (yet)
-    // but we cleanup the listener when the EngineImpl instance goes out of scope.
-    // In this case the Choreographer is still running and we need to stop it.
-    _choreographer->stop();
-  }
-}
-
 void EngineImpl::setSurfaceProvider(std::shared_ptr<SurfaceProvider> surfaceProvider) {
   if (surfaceProvider == nullptr) {
     [[unlikely]];

--- a/package/cpp/core/EngineImpl.h
+++ b/package/cpp/core/EngineImpl.h
@@ -59,7 +59,6 @@ class EngineImpl : public std::enable_shared_from_this<EngineImpl>, public Runti
 public:
   explicit EngineImpl(std::shared_ptr<Choreographer> choreographer, std::shared_ptr<Dispatcher> rendererDispatcher,
                       std::shared_ptr<Engine> engine);
-  ~EngineImpl();
 
   void setSurfaceProvider(std::shared_ptr<SurfaceProvider> surfaceProvider);
   void setRenderCallback(std::optional<RenderCallback> callback);


### PR DESCRIPTION
Reverting some of the changes introduced in:

- https://github.com/margelo/react-native-filament/pull/139

1. we can't hold a reference to the EngineImpl in the surface, otherwise when onSurfaceDestroyed doesn't gets called as on iOS we never release the EngineImpl leading to memory leaks. So this code was removed.
2. the main issue is that in the onSurfaceDestroyed listener we were implicitly removing the listener itself, which leads to a deadlock. This problem is really hard to come around. When we release the swapChain in onSurfaceDestroyed (which we have to do when the surface gets destroyed), we very likely cause the releasing of the EngineImpl itself as the swap chain was the last part holding a ref on it. So onSurfaceDestroyed implicitly calls `~EngineImpl` which will release our surface listener, and then we have a deadlock because.
This was fixed by using a recursive mutex. I experimented with copying the listeners in the listener manager in the forEach and only locking the copy operation. The performance impact was very small (on low end device ~10µs) - however the recursive mutex was more performant only adding 0-1µs on a low end device (and mostly no difference on high end devices)