### PR TITLE
fix: fix choreographer not being stopped

### DIFF
--- a/package/android/src/main/java/com/margelo/filament/FilamentChoreographer.java
+++ b/package/android/src/main/java/com/margelo/filament/FilamentChoreographer.java
@@ -1,5 +1,6 @@
 package com.margelo.filament;
 
+import android.util.Log;
 import android.view.Choreographer;
 
 import androidx.annotation.Keep;
@@ -9,9 +10,13 @@ import com.facebook.proguard.annotations.DoNotStrip;
 
 import dalvik.annotation.optimization.FastNative;
 
-/** @noinspection JavaJniMissingFunction*/
+/**
+ * @noinspection JavaJniMissingFunction
+ */
 public class FilamentChoreographer {
-    /** @noinspection unused, FieldCanBeLocal */
+    /**
+     * @noinspection unused, FieldCanBeLocal
+     */
     @DoNotStrip
     @Keep
     private final HybridData mHybridData;
@@ -29,27 +34,34 @@ public class FilamentChoreographer {
         choreographer.postFrameCallback(this::onFrameCallback);
     }
 
-    /** @noinspection unused */
+    /**
+     * @noinspection unused
+     */
     @DoNotStrip
     @Keep
     private synchronized void start() {
         if (!isRunning) {
             isRunning = true;
             choreographer.postFrameCallback(this::onFrameCallback);
+            Log.d("FilamentChoreographer", "Started choreographer!");
         }
     }
 
-    /** @noinspection unused */
+    /**
+     * @noinspection unused
+     */
     @DoNotStrip
     @Keep
     private synchronized void stop() {
         if (isRunning) {
             isRunning = false;
             choreographer.removeFrameCallback(this::onFrameCallback);
+            Log.d("FilamentChoreographer", "Stopped choreographer!");
         }
     }
 
     private native HybridData initHybrid();
+
     @FastNative
     private native void onFrame(long timestamp);
 }

--- a/package/cpp/core/EngineImpl.cpp
+++ b/package/cpp/core/EngineImpl.cpp
@@ -84,6 +84,15 @@ EngineImpl::EngineImpl(std::shared_ptr<Choreographer> choreographer, std::shared
   _view->setCamera(_camera.get());
 }
 
+EngineImpl::~EngineImpl() {
+  if (_choreographer) {
+    // It can happen that the onSurfaceDestroyed callback wasn't called (yet)
+    // but we cleanup the listener when the EngineImpl instance goes out of scope.
+    // In this case the Choreographer is still running and we need to stop it.
+    _choreographer->stop();
+  }
+}
+
 void EngineImpl::setSurfaceProvider(std::shared_ptr<SurfaceProvider> surfaceProvider) {
   if (surfaceProvider == nullptr) {
     [[unlikely]];

--- a/package/cpp/core/EngineImpl.h
+++ b/package/cpp/core/EngineImpl.h
@@ -59,6 +59,7 @@ class EngineImpl : public std::enable_shared_from_this<EngineImpl>, public Runti
 public:
   explicit EngineImpl(std::shared_ptr<Choreographer> choreographer, std::shared_ptr<Dispatcher> rendererDispatcher,
                       std::shared_ptr<Engine> engine);
+  ~EngineImpl() override;
 
   void setSurfaceProvider(std::shared_ptr<SurfaceProvider> surfaceProvider);
   void setRenderCallback(std::optional<RenderCallback> callback);

--- a/package/ios/src/AppleChoreographer.mm
+++ b/package/ios/src/AppleChoreographer.mm
@@ -20,10 +20,12 @@ AppleChoreographer::~AppleChoreographer() {
 }
 
 void AppleChoreographer::stop() {
+  NSLog(@"Stopping choreographer");
   [_displayLink stop];
 }
 
 void AppleChoreographer::start() {
+  NSLog(@"Starting choreographer");
   [_displayLink start];
 }
 


### PR DESCRIPTION
We were only stopping the choreographer in `onSurfaceDestroyed`:

- This isn't called on iOS
- On android it _might_ be called. If our `EngineImpl` instance, which holds the `onSurfaceDestroyed` listener, is destroyed before `onSurfaceDestroyed` was called it will clear up the listener and never call `onSurfaceDestroyed`, thus never stopping the choreographer.