### PR TITLE
fix(ios): fix bug where the rendering would stop / would be gone when returning from background

### DIFF
--- a/package/ios/src/DisplayLinkListener.m
+++ b/package/ios/src/DisplayLinkListener.m
@@ -12,18 +12,24 @@
 @implementation DisplayLinkListener {
   CADisplayLink* _Nullable _displayLink;
   OnFrameCallback _callback;
-    bool shouldContinueOnEnterForeground;
+  bool shouldContinueOnEnterForeground;
 }
 - (instancetype)initWithCallback:(OnFrameCallback)callback {
   if (self = [super init]) {
     _callback = callback;
     _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onFrame:)];
     _displayLink.paused = YES;
-      shouldContinueOnEnterForeground = NO;
+    shouldContinueOnEnterForeground = NO;
     [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
-      
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidEnterBackground) name:UIApplicationDidEnterBackgroundNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appWillEnterForeground) name:UIApplicationWillEnterForegroundNotification object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(appDidEnterBackground)
+                                                 name:UIApplicationDidEnterBackgroundNotification
+                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(appWillEnterForeground)
+                                                 name:UIApplicationWillEnterForegroundNotification
+                                               object:nil];
   }
   return self;
 }
@@ -33,7 +39,7 @@
 }
 
 - (void)stop {
-  _displayLink.paused = NO;
+  _displayLink.paused = YES;
 }
 
 - (void)invalidate {
@@ -49,16 +55,16 @@
 // When the app enters the background we need to stop sending commands to metal.
 // Otherwise we run the risk of the metal view becoming blank, or not being able to update it anymore.
 - (void)appDidEnterBackground {
-    shouldContinueOnEnterForeground = !_displayLink.paused;
-    _displayLink.paused = YES;
-    NSLog(@"[react-native-filament] [DisplayLinkListener] Paused rendering, app entered background.");
+  shouldContinueOnEnterForeground = !_displayLink.paused;
+  _displayLink.paused = YES;
+  NSLog(@"[react-native-filament] [DisplayLinkListener] Paused rendering, app entered background.");
 }
 
 - (void)appWillEnterForeground {
-    if (shouldContinueOnEnterForeground){
-        _displayLink.paused = NO;
-        NSLog(@"[react-native-filament] [DisplayLinkListener] Resumed rendering, app entered foreground.");
-    }
+  if (shouldContinueOnEnterForeground) {
+    _displayLink.paused = NO;
+    NSLog(@"[react-native-filament] [DisplayLinkListener] Resumed rendering, app entered foreground.");
+  }
 }
 
 - (void)dealloc {


### PR DESCRIPTION
There was a bug where the rendering / view content seemed to be gone when the user returned to the app from background after having it in the bg for a while.

I assume the problem is that we somehow send further commands to metal, which we shouldn't do:

https://developer.apple.com/documentation/metal/gpu_devices_and_work_submission/preparing_your_metal_app_to_run_in_the_background?language=objc 

There were similar problems reported in rnskia:

- https://github.com/Shopify/react-native-skia/pull/1259