### PR TITLE
fix: move jsi::Function destructor check to JSIConverter

### DIFF
--- a/package/cpp/jsi/JSIConverter.h
+++ b/package/cpp/jsi/JSIConverter.h
@@ -8,6 +8,7 @@
 #include "HybridObject.h"
 #include "Promise.h"
 #include "PromiseFactory.h"
+#include "RNFWorkletRuntimeRegistry.h"
 #include "threading/Dispatcher.h"
 #include <array>
 #include <future>
@@ -199,7 +200,30 @@ template <typename TResult> struct JSIConverter<std::future<TResult>> {
 template <typename ReturnType, typename... Args> struct JSIConverter<std::function<ReturnType(Args...)>> {
   static std::function<ReturnType(Args...)> fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
     jsi::Function function = arg.asObject(runtime).asFunction(runtime);
-    std::shared_ptr<jsi::Function> sharedFunction = std::make_shared<jsi::Function>(std::move(function));
+
+    std::shared_ptr<jsi::Function> sharedFunction(new jsi::Function(std::move(function)), [&runtime](jsi::Function* ptr) {
+      if (RNFWorkletRuntimeRegistry::isRuntimeAlive(&runtime)) {
+        // Only delete the jsi::Function when the runtime it created is still alive.
+        // Otherwise leak memory. We do this on purpose, as sometimes we would keep
+        // references to JSI objects past the lifetime of its runtime (e.g.,
+        // shared values references from the RN VM holds reference to JSI objects
+        // on the UI runtime). When the runtime is terminated, the orphaned JSI
+        // objects would crash the app when their destructors are called, because
+        // they call into a memory that's managed by the terminated runtime. We
+        // accept the tradeoff of leaking memory here, as it has a limited impact.
+        // This scenario can only occur when the React instance is torn down which
+        // happens in development mode during app reloads, or in production when
+        // the app is being shut down gracefully by the system. An alternative
+        // solution would require us to keep track of all JSI values that are in
+        // use which would require additional data structure and compute spent on
+        // bookkeeping that only for the sake of destroying the values in time
+        // before the runtime is terminated. Note that the underlying memory that
+        // jsi::Value refers to is managed by the VM and gets freed along with the
+        // runtime.
+        delete ptr;
+      }
+    });
+
     return [&runtime, sharedFunction](Args... args) -> ReturnType {
       jsi::Value result = sharedFunction->call(runtime, JSIConverter<std::decay_t<Args>>::toJSI(runtime, args)...);
       if constexpr (std::is_same_v<ReturnType, void>) {


### PR DESCRIPTION
There is the general problem that we hold a reference to `jsi::Function`s, and these reference might be released only after the runtime which created the `jsi::Function` is already destroyed. We will then get a crash when the `jsi::Function` destructor is being called.

In RNF we hold `jsi::Function`s that we receive from the `JSIConverter`. In the `JSIConverter` we create a a new shared_ptr based `jsi::Function`, which we can pass & copy around. We pass it to a lambda, and that is the lambda that we store (e.g. in the choreographer as render callback).

This fix adds a custom deleter function for the shared_ptr of the `jsi::Function` and only deletes its memory / call its destructor when the runtime it created is still alive.

This fix is more holistic than the current check in the HybridObject function cache clearance.

As it can be seen here in this crash stack the destructor is called from the JSIConverter's lambda:

![Screenshot 2024-05-15 at 17 40 37](https://github.com/margelo/react-native-filament/assets/16821682/dbab597e-cecf-4009-b8d8-b67c78e69c12)
