### PR TITLE
fix: fix hybridobject's jsi::Function cleanup

### DIFF
--- a/package/cpp/jsi/HybridObject.cpp
+++ b/package/cpp/jsi/HybridObject.cpp
@@ -89,7 +89,8 @@ jsi::Value HybridObject::get(facebook::jsi::Runtime& runtime, const facebook::js
     HybridFunction& hybridFunction = _methods.at(name);
     jsi::Function function = jsi::Function::createFromHostFunction(runtime, jsi::PropNameID::forUtf8(runtime, name),
                                                                    hybridFunction.parameterCount, hybridFunction.function);
-    functionCache[name] = std::make_shared<jsi::Function>(std::move(function));
+
+    functionCache[name] = JSIHelper::createSharedJsiFunction(runtime, std::move(function));
     return jsi::Value(runtime, *functionCache[name]);
   }
 

--- a/package/cpp/jsi/JSIConverter.h
+++ b/package/cpp/jsi/JSIConverter.h
@@ -6,6 +6,7 @@
 
 #include "EnumMapper.h"
 #include "HybridObject.h"
+#include "JSIHelper.h"
 #include "Promise.h"
 #include "PromiseFactory.h"
 #include "RNFWorkletRuntimeRegistry.h"
@@ -201,29 +202,7 @@ template <typename ReturnType, typename... Args> struct JSIConverter<std::functi
   static std::function<ReturnType(Args...)> fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
     jsi::Function function = arg.asObject(runtime).asFunction(runtime);
 
-    std::shared_ptr<jsi::Function> sharedFunction(new jsi::Function(std::move(function)), [&runtime](jsi::Function* ptr) {
-      if (RNFWorkletRuntimeRegistry::isRuntimeAlive(&runtime)) {
-        // Only delete the jsi::Function when the runtime it created is still alive.
-        // Otherwise leak memory. We do this on purpose, as sometimes we would keep
-        // references to JSI objects past the lifetime of its runtime (e.g.,
-        // shared values references from the RN VM holds reference to JSI objects
-        // on the UI runtime). When the runtime is terminated, the orphaned JSI
-        // objects would crash the app when their destructors are called, because
-        // they call into a memory that's managed by the terminated runtime. We
-        // accept the tradeoff of leaking memory here, as it has a limited impact.
-        // This scenario can only occur when the React instance is torn down which
-        // happens in development mode during app reloads, or in production when
-        // the app is being shut down gracefully by the system. An alternative
-        // solution would require us to keep track of all JSI values that are in
-        // use which would require additional data structure and compute spent on
-        // bookkeeping that only for the sake of destroying the values in time
-        // before the runtime is terminated. Note that the underlying memory that
-        // jsi::Value refers to is managed by the VM and gets freed along with the
-        // runtime.
-        delete ptr;
-      }
-    });
-
+    std::shared_ptr<jsi::Function> sharedFunction = JSIHelper::createSharedJsiFunction(runtime, std::move(function));
     return [&runtime, sharedFunction](Args... args) -> ReturnType {
       jsi::Value result = sharedFunction->call(runtime, JSIConverter<std::decay_t<Args>>::toJSI(runtime, args)...);
       if constexpr (std::is_same_v<ReturnType, void>) {

--- a/package/cpp/jsi/JSIHelper.h
+++ b/package/cpp/jsi/JSIHelper.h
@@ -1,0 +1,48 @@
+//
+// Created by Hanno Gödecke on 15.05.24.
+//
+
+#pragma once
+
+#include "RNFWorkletRuntimeRegistry.h"
+#include <jsi/jsi.h>
+#include <memory>
+
+namespace margelo {
+
+using namespace facebook;
+
+class JSIHelper {
+public:
+  /**
+   * Takes a jsi::Function and wraps it in a shared_ptr so its shareable.
+   * Every jsi::Function you intend to share or hold should be wrapped using this function.
+   */
+  static std::shared_ptr<jsi::Function> createSharedJsiFunction(jsi::Runtime& runtime, jsi::Function&& function) {
+    std::shared_ptr<jsi::Function> sharedFunction(new jsi::Function(std::move(function)), [&runtime](jsi::Function* ptr) {
+      if (RNFWorkletRuntimeRegistry::isRuntimeAlive(&runtime)) {
+        // Only delete the jsi::Function when the runtime it created is still alive.
+        // Otherwise leak memory. We do this on purpose, as sometimes we would keep
+        // references to JSI objects past the lifetime of its runtime (e.g.,
+        // shared values references from the RN VM holds reference to JSI objects
+        // on the UI runtime). When the runtime is terminated, the orphaned JSI
+        // objects would crash the app when their destructors are called, because
+        // they call into a memory that's managed by the terminated runtime. We
+        // accept the tradeoff of leaking memory here, as it has a limited impact.
+        // This scenario can only occur when the React instance is torn down which
+        // happens in development mode during app reloads, or in production when
+        // the app is being shut down gracefully by the system. An alternative
+        // solution would require us to keep track of all JSI values that are in
+        // use which would require additional data structure and compute spent on
+        // bookkeeping that only for the sake of destroying the values in time
+        // before the runtime is terminated. Note that the underlying memory that
+        // jsi::Value refers to is managed by the VM and gets freed along with the
+        // runtime.
+        delete ptr;
+      }
+    });
+
+    return sharedFunction;
+  }
+};
+} // namespace margelo


### PR DESCRIPTION
Follow up of:

- https://github.com/margelo/react-native-filament/pull/178

I was missing that in HybridObject we also create a new jsi::Function. So I created a `createSharedJsiFunction` helper method that can be used in all places creating jsi::Functions