### PR TITLE
fix: fix filament view stopping randomly

### DIFF
--- a/package/cpp/FilamentView.cpp
+++ b/package/cpp/FilamentView.cpp
@@ -19,7 +19,15 @@ void FilamentView::loadHybridMethods() {
   registerHybridMethod("setChoreographer", &FilamentView::setChoreographer, this);
 }
 
-void FilamentView::setChoreographer(std::shared_ptr<ChoreographerWrapper> choreographerWrapper) {
+void FilamentView::setChoreographer(std::optional<std::shared_ptr<ChoreographerWrapper>> choreographerWrapperOrNull) {
+  if (!choreographerWrapperOrNull.has_value()) {
+    Logger::log(TAG, "Removing reference to choreographer.");
+    _choreographer = nullptr;
+    _onSurfaceDestroyedListener = nullptr;
+    return;
+  }
+
+  std::shared_ptr<ChoreographerWrapper> choreographerWrapper = choreographerWrapperOrNull.value();
   auto choreographer = choreographerWrapper->getChoreographer();
   _choreographer = choreographer;
 

--- a/package/cpp/FilamentView.h
+++ b/package/cpp/FilamentView.h
@@ -27,7 +27,7 @@ public:
   void loadHybridMethods() override;
 
 private: // Exposed JS API
-  void setChoreographer(std::shared_ptr<ChoreographerWrapper> choreographerWrapper);
+  void setChoreographer(std::optional<std::shared_ptr<ChoreographerWrapper>> choreographerWrapperOrNull);
 
 private:
   std::shared_ptr<Choreographer> _choreographer = nullptr;

--- a/package/src/native/FilamentViewTypes.ts
+++ b/package/src/native/FilamentViewTypes.ts
@@ -36,5 +36,5 @@ export interface FilamentView {
    * @private
    * Links the surface with the choreographer. When the view gets destroyed, the choreographer will be stopped.
    */
-  setChoreographer(choreographer: Choreographer): void
+  setChoreographer(choreographer?: Choreographer): void
 }


### PR DESCRIPTION
A previous FilamentView might be deleted at a later point as it held a reference to the same choreographer that is used by a new instance of a FilamentView