### PR TITLE
fix: fix crash on createAnimator due to name being nullptr

### DIFF
--- a/package/cpp/core/AnimatorWrapper.cpp
+++ b/package/cpp/core/AnimatorWrapper.cpp
@@ -100,7 +100,7 @@ int AnimatorWrapper::addToSyncList(std::shared_ptr<FilamentInstanceWrapper> inst
 
   int id = _syncId++;
   FilamentInstance* instance = instanceWrapper->getInstance();
-  std::map<std::string, Entity> entityMap = getEntityNameMap(instance);
+  std::map<std::string, Entity> entityMap = createEntityNameMap(instance);
   _syncMap.insert({id, instance});
   _instanceEntityMap.insert({id, entityMap});
 
@@ -121,7 +121,7 @@ void AnimatorWrapper::removeFromSyncList(int instanceId) {
   _instanceEntityMap.erase(instanceId);
 }
 
-EntityNameMap AnimatorWrapper::getEntityNameMap(FilamentInstance* instance) {
+EntityNameMap AnimatorWrapper::createEntityNameMap(FilamentInstance* instance) {
   assertInstanceNotNull(instance);
 
   size_t masterEntitiesCount = instance->getEntityCount();
@@ -134,6 +134,9 @@ EntityNameMap AnimatorWrapper::getEntityNameMap(FilamentInstance* instance) {
       continue;
     }
     auto masterInstanceName = _nameComponentManager->getName(masterNameInstance);
+    if (masterInstanceName == nullptr) {
+      continue;
+    }
     entityMap[masterInstanceName] = masterEntity;
   }
 

--- a/package/cpp/core/AnimatorWrapper.h
+++ b/package/cpp/core/AnimatorWrapper.h
@@ -21,7 +21,7 @@ class AnimatorWrapper : public HybridObject {
 public:
   explicit AnimatorWrapper(Animator* animator, FilamentInstance* instance, std::shared_ptr<NameComponentManager> nameComponentManager)
       : HybridObject("AnimatorWrapper"), _animator(animator), _instance(instance), _nameComponentManager(nameComponentManager),
-        _entityMap(getEntityNameMap(instance)) {}
+        _entityMap(createEntityNameMap(instance)) {}
 
   void loadHybridMethods() override;
 
@@ -40,7 +40,7 @@ private: // Internal
   /**
    * Creates a map of entities and their names
    */
-  EntityNameMap getEntityNameMap(FilamentInstance* instance);
+  EntityNameMap createEntityNameMap(FilamentInstance* instance);
   /**
    * Will take all entities associates with this animator instance and apply it to the provided entities
    */


### PR DESCRIPTION
The following crash is addressed by this PR:

![Screenshot 2024-05-21 at 09 35 50](https://github.com/margelo/react-native-filament/assets/16821682/ea23bfd9-1666-4e0b-b7ed-9cd550587979)
