### PR TITLE
fix: fix crash in useAnimator

### DIFF
--- a/package/src/hooks/useAnimator.ts
+++ b/package/src/hooks/useAnimator.ts
@@ -3,22 +3,28 @@ import { Animator, FilamentAsset, FilamentInstance } from '../types'
 import { useFilamentContext } from '../FilamentContext'
 import { FilamentModel } from './useModel'
 
+function isFilamentModel(asset: FilamentAsset | FilamentInstance | FilamentModel): asset is FilamentModel {
+  // @ts-expect-error Because asset is a HostObject and using "in" check is a) expensive and b) somehow broken
+  return asset.state != null
+}
+
 /**
  * Creates a animator for the given {@linkcode FilamentAsset} or {@linkcode FilamentInstance}.
  *
  * @note For each asset/instance you should only have one animator.
  */
-export function useAnimator(asset?: FilamentAsset | FilamentInstance | FilamentModel): Animator | undefined {
+export function useAnimator(modelOrAsset?: FilamentAsset | FilamentInstance | FilamentModel): Animator | undefined {
   const { nameComponentManager } = useFilamentContext()
   const animator = useMemo(() => {
-    if (asset == null) return undefined
-    if ('state' in asset) {
-      if (asset.state === 'loading') return undefined
-      const modelAsset = asset.asset
-      return modelAsset.createAnimator(nameComponentManager)
+    if (modelOrAsset == null) return undefined
+
+    if (isFilamentModel(modelOrAsset)) {
+      if (modelOrAsset.state === 'loading') return undefined
+      const { asset } = modelOrAsset
+      return asset.createAnimator(nameComponentManager)
     }
 
-    return asset.createAnimator(nameComponentManager)
-  }, [asset, nameComponentManager])
+    return modelOrAsset.createAnimator(nameComponentManager)
+  }, [modelOrAsset, nameComponentManager])
   return animator
 }


### PR DESCRIPTION
In useAnimator we were using an `in` check for checking the type. However, there seems to be a bug with HostObjects where this always returns true.
We thus changed the check by checking if the `state` property is set to detect if its a model