### PR TITLE
fix: fix a potential crash in the choreographer

### DIFF
--- a/package/cpp/RNFChoreographerWrapper.h
+++ b/package/cpp/RNFChoreographerWrapper.h
@@ -16,6 +16,7 @@ using RenderCallback = std::function<void(FrameInfo)>;
 class ChoreographerWrapper : public PointerHolder<Choreographer>, public RuntimeLifecycleListener {
 public:
   explicit ChoreographerWrapper(std::shared_ptr<Choreographer> choreographer) : PointerHolder(TAG, choreographer) {}
+  ~ChoreographerWrapper() override;
 
   void loadHybridMethods() override;
 
@@ -30,7 +31,7 @@ private: // Exposed JS API
   void release() override;
 
 private: // Internal
-  void cleanup();
+  void stopAndRemoveListeners();
   void onRuntimeDestroyed(jsi::Runtime*) override;
   FrameInfo createFrameInfo(double timestamp);
 


### PR DESCRIPTION
Its possible that the ChoreographerWrapper will be released automatically early, in this case we should stop the choreographer as well