### PR TITLE
fix: call onReadyForMoreData / renderFrame as long as isReadyForMoreMediaData is true

### DIFF
--- a/package/ios/src/RNFAppleFilamentRecorder.mm
+++ b/package/ios/src/RNFAppleFilamentRecorder.mm
@@ -198,6 +198,9 @@ std::future<void> AppleFilamentRecorder::startRecording() {
                                                      if (self != nullptr) {
                                                          auto futurePromise = self->_renderThreadDispatcher->runAsyncAwaitable<void>([self]() {
                                                            while([self->_assetWriterInput isReadyForMoreMediaData]) {
+                                                             // This will cause our JS render callbacks to be called, which will call renderFrame
+                                                             // renderFrame will call appendPixelBuffer, and we should call appendPixelBuffer
+                                                             // as long as isReadyForMoreMediaData is true.
                                                              bool shouldContinueNext = self->onReadyForMoreData();
                                                              if (!shouldContinueNext) {
                                                                // stop the render queue
@@ -205,6 +208,7 @@ std::future<void> AppleFilamentRecorder::startRecording() {
                                                              }
                                                            }
                                                          });
+                                                         // The block in requestMediaDataWhenReadyOnQueue needs to call appendPixelBuffer synchronously
                                                          futurePromise.get();
                                                        }
                                                    }];


### PR DESCRIPTION
I strictly followed the example from the apple documentation:

![Screenshot 2024-06-17 at 15 45 09](https://github.com/margelo/react-native-filament/assets/16821682/e420d5c0-02e3-4347-8ac4-3d95b91533a3)

We should call `appendSampleBuffer` as long as `isReadyForMoreMediaData` returns true.

In my testings this resulted in slightly faster and continuously rendering. In the current implementation where we block of `requestMediaDataWhenReadyOnQueue` gets called thousand times, the rendering only happens in chunks, and in between it's completely stuck.