### PR TITLE
fix: metro bundler `The 'declare' modifier is only allowed when the...` error

### DIFF
--- a/package/src/react/FilamentView.tsx
+++ b/package/src/react/FilamentView.tsx
@@ -50,7 +50,8 @@ export class FilamentView extends React.PureComponent<FilamentProps> {
    * @note Not available in the constructor!
    */
   static contextType = FilamentContext
-  declare context: React.ContextType<typeof FilamentContext>
+  // @ts-expect-error We can't use the declare keyword here as react-natives metro babel preset isn't able to handle it yet
+  context!: React.ContextType<typeof FilamentContext>
 
   constructor(props: FilamentProps) {
     super(props)


### PR DESCRIPTION
![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-14 at 17 52 04](https://github.com/user-attachments/assets/6d5cb3ae-61fc-4b5e-9b36-ff9f294bbe4c)
