### PR TITLE
fix: `useWorkletCallback` returned unstable ref

### DIFF
--- a/package/src/hooks/useWorkletCallback.ts
+++ b/package/src/hooks/useWorkletCallback.ts
@@ -1,6 +1,7 @@
-import { useWorklet } from 'react-native-worklets-core'
+import { getWorkletDependencies } from 'react-native-worklets-core'
 import { useFilamentContext } from './useFilamentContext'
 import { wrapWithErrorHandler } from '../ErrorUtils'
+import { useMemo } from 'react'
 
 /**
  * Creates a callback that can be executed in he separate worklet thread of the engine.
@@ -8,5 +9,19 @@ import { wrapWithErrorHandler } from '../ErrorUtils'
 export function useWorkletCallback<T extends (...args: any[]) => any>(callback: T): (...args: Parameters<T>) => Promise<ReturnType<T>> {
   const { workletContext } = useFilamentContext()
 
-  return useWorklet(workletContext, wrapWithErrorHandler(callback))
+  // Note: from react-native-worklets-core/useWorklet
+  // As we want to wrap using `wrapWithErrorHandler` the dependencies must be captured from the
+  // callback, not from the wrapper.
+
+  // As a dependency for this use-memo we use all of the values captured inside the worklet,
+  // as well as the unique context name.
+  const dependencies = [...getWorkletDependencies(callback)]
+
+  return useMemo(
+    () => {
+      return workletContext.createRunAsync(wrapWithErrorHandler(callback))
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    dependencies
+  )
 }


### PR DESCRIPTION
Before we were passing `wrapWithErrorHandler(callback)` to `useWorklet`, which would get as dependencies from the closure only `callback`, which is a unstable function, so I had to copy the mechanics from useWorkelt manually here to get the reps from the correct inner callback.