### PR TITLE
chore(docs): import defaultAssetExts

### DIFF
--- a/docs/docs/guides/GETTING_STARTED.mdx
+++ b/docs/docs/guides/GETTING_STARTED.mdx
@@ -100,7 +100,6 @@ You'll likely import 3D related files when using react-native-filament. To make 
 
 ```js
 const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
-const defaultAssetExts = require("metro-config/src/defaults/defaults").assetExts;
 
 const defaultConfig = getDefaultConfig(__dirname)
 
@@ -113,7 +112,7 @@ const defaultConfig = getDefaultConfig(__dirname)
 const config = {
     resolver: {
         // This makes it possible to import .glb files in your code:
-        assetExts: [...defaultAssetExts, 'glb']
+        assetExts: [...(defaultConfig.resolver?.assetExts || []), 'glb']
     }
 };
 

--- a/docs/docs/guides/GETTING_STARTED.mdx
+++ b/docs/docs/guides/GETTING_STARTED.mdx
@@ -100,6 +100,9 @@ You'll likely import 3D related files when using react-native-filament. To make 
 
 ```js
 const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
+const defaultAssetExts = require("metro-config/src/defaults/defaults").assetExts;
+
+const defaultConfig = getDefaultConfig(__dirname)
 
 /**
  * Metro configuration
@@ -110,11 +113,9 @@ const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
 const config = {
     resolver: {
         // This makes it possible to import .glb files in your code:
-        assetExts: ['glb']
+        assetExts: [...defaultAssetExts, 'glb']
     }
 };
-
-const defaultConfig = getDefaultConfig(__dirname)
 
 module.exports = mergeConfig(defaultConfig, config);
 ```


### PR DESCRIPTION
A quick update on documentation about metro resolver `assetExts`

Most projects need the default metro extensions, so I think it's useful to indicate this in the documentation.

There are many ways to do it, I let you decide what's your favorite one