### PR TITLE
perf(ios): mark metal layer for rendering only

### DIFF
--- a/package/ios/src/RNFFilamentMetalView.mm
+++ b/package/ios/src/RNFFilamentMetalView.mm
@@ -19,6 +19,7 @@
   if (self = [super init]) {
     CAMetalLayer* metalLayer = (CAMetalLayer*)self.layer;
     metalLayer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    metalLayer.framebufferOnly = YES;
     isMounted = false;
   }
   return self;


### PR DESCRIPTION
Means that the CAMetalLayer will be for rendering only and cannot be used for reading/sampling (read pixel f.ex.). Makes it easier for iOS to optimise.