### PR TITLE
fix: #242 exported worklet functions are undefined

### DIFF
--- a/package/src/ErrorUtils.ts
+++ b/package/src/ErrorUtils.ts
@@ -29,14 +29,14 @@ const throwErrorOnJS = Worklets.createRunOnJS((message: string, stack: string | 
   reportError(error, fatal)
 })
 
-export function reportWorkletError(error: unknown, fatal = true): void {
+export const reportWorkletError = (error: unknown, fatal = true): void => {
   'worklet'
   const safeError = error as Error | undefined
   const message = safeError != null && 'message' in safeError ? safeError.message : 'Filament threw an error.'
   throwErrorOnJS(message, safeError?.stack, fatal)
 }
 
-export function wrapWithErrorHandler<T extends (...args: any[]) => any>(callback: T): (...args: Parameters<T>) => ReturnType<T> {
+export const wrapWithErrorHandler = <T extends (...args: any[]) => any>(callback: T): ((...args: Parameters<T>) => ReturnType<T>) => {
   return (...args: Parameters<T>): ReturnType<T> => {
     'worklet'
     try {

--- a/package/src/utilities/helper.ts
+++ b/package/src/utilities/helper.ts
@@ -1,11 +1,11 @@
 import { ISharedValue } from 'react-native-worklets-core'
 import { Float3 } from '../types'
 
-export function areFloat3Equal(a: Float3, b?: Float3): boolean {
+export const areFloat3Equal = (a: Float3, b?: Float3): boolean => {
   return a[0] === b?.[0] && a[1] === b?.[1] && a[2] === b?.[2]
 }
 
-export function isWorkletSharedValue(value: any): value is ISharedValue<any> {
+export const isWorkletSharedValue = (value: any): value is ISharedValue<any> => {
   'worklet'
   return typeof value === 'object' && value != null && 'addListener' in value && typeof value.addListener === 'function'
 }


### PR DESCRIPTION
Fixes: https://github.com/margelo/react-native-filament/issues/242

The problem is with the reanimated/worklets babel plugin, and has been reported here:

- https://github.com/software-mansion/react-native-reanimated/issues/5365

The babel plugin that transpiles our typescript code transforms the typescript to this commonjs code:

| Typescript | CommonJS |
|--------|--------|
| ![Screenshot 2024-07-23 at 11 31 24](https://github.com/user-attachments/assets/1fae995d-c195-4d09-b8e3-ff225e5fe280) | ![Screenshot 2024-07-23 at 11 31 09](https://github.com/user-attachments/assets/236ef850-3d76-4cd9-86ac-e5265d38c3a8) |

As it can be seen the exports / usage of the variable happens before the function is declared, which causes the worklet function to be undefined (as reported in the REA issue above).

## Solution

I checked out rnskia is doing it, and they use const and anonymous functions, which is indeed working as the export then happens after the declaration:

![Screenshot 2024-07-23 at 11 30 54](https://github.com/user-attachments/assets/bed849af-87cd-4d6b-abfc-4db7f4a4c756)

So from now on **we must export all worklet functions as const arrow functions**


## Alternative solutions

I tried to do it as reanimated and remove the CommonJS support, and only create a ES module. However, that didn't work due to some react native bugs, where it can't find the codegen component anymore.