### PR TITLE
Update PhysicsCoin example: remove collision callback after handling callback

### DIFF
--- a/package/example/Shared/src/PhysicsCoin.tsx
+++ b/package/example/Shared/src/PhysicsCoin.tsx
@@ -16,7 +16,6 @@ import {
   CollisionCallback,
 } from 'react-native-filament'
 import { useCoin } from './useCoin'
-import { useSharedValue } from 'react-native-worklets-core'
 
 function PhysicsCoinRenderer() {
   const world = useWorld(0, -9, 0)
@@ -34,7 +33,6 @@ function PhysicsCoinRenderer() {
     id: 'floor',
   })
 
-  const hasNotifiedTouchedFloor = useSharedValue(false)
   const [coinABody, coinAEntity] = useCoin(
     world,
     [0, 3, 0.0],

--- a/package/example/Shared/src/PhysicsCoin.tsx
+++ b/package/example/Shared/src/PhysicsCoin.tsx
@@ -13,6 +13,7 @@ import {
   FilamentScene,
   DefaultLight,
   Camera,
+  CollisionCallback,
 } from 'react-native-filament'
 import { useCoin } from './useCoin'
 import { useSharedValue } from 'react-native-worklets-core'
@@ -37,20 +38,15 @@ function PhysicsCoinRenderer() {
   const [coinABody, coinAEntity] = useCoin(
     world,
     [0, 3, 0.0],
-    useWorkletCallback((_thisBody, collidedWith) => {
+    useWorkletCallback<CollisionCallback>((coinRigidBody, collidedWith) => {
       'worklet'
-
-      if (hasNotifiedTouchedFloor.value) {
-        // TODO: This keeps getting called. Maybe we want to add a unsubscribe mechanism?
-        return
-      }
 
       if (collidedWith.id !== 'floor') {
         return
       }
 
-      hasNotifiedTouchedFloor.value = true
       console.log('Coin touched the floor!')
+      coinRigidBody.setCollisionCallback(undefined);      
     })
   )
   const [coinBBody, coinBEntity] = useCoin(world, [0, 3, 0.5])


### PR DESCRIPTION
Update PhysicsCoin to remove collision callback after handling callback

Found a way to remove the callback subscription for following todo .       

> TODO: This keeps getting called. Maybe we want to add a unsubscribe mechanism?