### PR TITLE
add(android): support 16 KB page sizes

### DIFF
--- a/package/android/CMakeLists.txt
+++ b/package/android/CMakeLists.txt
@@ -167,6 +167,13 @@ foreach(file ${BULLET3_LIBRARIES})
     target_link_libraries(${PACKAGE_NAME} ${file})
 endforeach()
 
-if(CMAKE_ANDROID_NDK_VERSION VERSION_LESS "27")
+if(DEFINED CMAKE_ANDROID_NDK_VERSION AND CMAKE_ANDROID_NDK_VERSION VERSION_LESS "27")
+  if(CMAKE_VERSION VERSION_LESS "3.13")
+    # Old CMake fallback
+    set_property(TARGET ${PACKAGE_NAME} APPEND PROPERTY
+      LINK_FLAGS "-Wl,-z,max-page-size=16384")
+  else()
+    # Modern CMake; prefer LINKER: to avoid -Wl, when supported
     target_link_options(${PACKAGE_NAME} PRIVATE "-Wl,-z,max-page-size=16384")
+  endif()
 endif()

--- a/package/android/CMakeLists.txt
+++ b/package/android/CMakeLists.txt
@@ -173,7 +173,7 @@ if(DEFINED CMAKE_ANDROID_NDK_VERSION AND CMAKE_ANDROID_NDK_VERSION VERSION_LESS 
     set_property(TARGET ${PACKAGE_NAME} APPEND PROPERTY
       LINK_FLAGS "-Wl,-z,max-page-size=16384")
   else()
-    # Modern CMake; prefer LINKER: to avoid -Wl, when supported
+    # Modern CMake
     target_link_options(${PACKAGE_NAME} PRIVATE "-Wl,-z,max-page-size=16384")
   endif()
 endif()

--- a/package/android/CMakeLists.txt
+++ b/package/android/CMakeLists.txt
@@ -166,3 +166,7 @@ foreach(file ${BULLET3_LIBRARIES})
     message("RN Filament: Linking ${file}...")
     target_link_libraries(${PACKAGE_NAME} ${file})
 endforeach()
+
+if(CMAKE_ANDROID_NDK_VERSION VERSION_LESS "27")
+    target_link_options(${PACKAGE_NAME} PRIVATE "-Wl,-z,max-page-size=16384")
+endif()

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -105,7 +105,8 @@ android {
         cppFlags "-O2 -frtti -fexceptions -Wall -Wno-unused-variable -fstack-protector-all"
         arguments "-DANDROID_STL=c++_shared",
                 "-DRNF_ENABLE_LOGS=${enableLogs ? "ON" : "OFF"}",
-                "-DNODE_MODULES_DIR=${nodeModules}"
+                "-DNODE_MODULES_DIR=${nodeModules}",
+                "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         abiFilters (*reactNativeArchitectures())
       }
     }


### PR DESCRIPTION
## Description

Adds support for 16 Kb page sizes for Android NDK r27 and lower. NDK 28+ doesn't require any special configuration, see [here](https://developer.android.com/guide/practices/page-sizes#compile-r28)