### PR TITLE
fix: move light intensity update to worklet effect to prevent crash

### DIFF
--- a/package/src/hooks/useLightEntity.ts
+++ b/package/src/hooks/useLightEntity.ts
@@ -1,7 +1,8 @@
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { LightConfig, LightManager } from '../types'
 import { ISharedValue } from 'react-native-worklets-core'
 import { useFilamentContext } from './useFilamentContext'
+import { useWorkletEffect } from './useWorkletEffect'
 
 export type UseLightEntityProps =
   | LightConfig
@@ -58,7 +59,8 @@ export function useLightEntity(lightManager: LightManager, config: UseLightEntit
 
   // Eventually subscribe to the intensity shared value
   const { workletContext } = useFilamentContext()
-  useEffect(() => {
+  useWorkletEffect(() => {
+    'worklet'
     const intensity = config.intensity
     if (intensity == null) return
     if (typeof intensity === 'number') return
@@ -71,7 +73,7 @@ export function useLightEntity(lightManager: LightManager, config: UseLightEntit
         setIntensity(entity, intensity.value)
       })
     )
-  }, [config.intensity, entity, lightManager, workletContext])
+  })
 
   return entity
 }


### PR DESCRIPTION
## Description

If we try updating light intensity's shared value (e.g. by pressing a Button) it works fine, however if we want to run constant updates in a `renderCallback` (say increase its value every frame) it crashes the app once we try to leave the scene. 

By running the update from a `useWorkletEffect` instead of a `useEffect` we prevent this behavior.

## Comparison

| Before                            | After                             |
|-----------------------------------|-----------------------------------|
|<video src="https://github.com/user-attachments/assets/0e80c5b0-0e01-4c0f-89b4-85c6174d3757"  />) | <video src="https://github.com/user-attachments/assets/3130949a-2bc2-40a6-ba9d-3ecab019673e"  /> |

## Steps to reproduce
I made this sample repo a couple of days ago to reproduce the issue:
https://github.com/gerzonc/rnf-intensity-sample