### PR TITLE
feat: make Light's colorKelvin animated via shared values

### DIFF
--- a/package/src/hooks/useLightEntity.ts
+++ b/package/src/hooks/useLightEntity.ts
@@ -1,7 +1,8 @@
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { LightConfig, LightManager } from '../types'
 import { ISharedValue } from 'react-native-worklets-core'
 import { useFilamentContext } from './useFilamentContext'
+import { useWorkletEffect } from './useWorkletEffect'
 
 export type UseLightEntityProps =
   | LightConfig
@@ -58,7 +59,8 @@ export function useLightEntity(lightManager: LightManager, config: UseLightEntit
 
   // Eventually subscribe to the intensity shared value
   const { workletContext } = useFilamentContext()
-  useEffect(() => {
+  useWorkletEffect(() => {
+    'worklet'
     const intensity = config.intensity
     if (intensity == null) return
     if (typeof intensity === 'number') return
@@ -71,7 +73,7 @@ export function useLightEntity(lightManager: LightManager, config: UseLightEntit
         setIntensity(entity, intensity.value)
       })
     )
-  }, [config.intensity, entity, lightManager, workletContext])
+  })
 
   return entity
 }

--- a/package/src/hooks/useLightEntity.ts
+++ b/package/src/hooks/useLightEntity.ts
@@ -3,7 +3,7 @@ import { LightConfig, LightManager } from '../types'
 import { ISharedValue } from 'react-native-worklets-core'
 import { useFilamentContext } from './useFilamentContext'
 import { useWorkletEffect } from './useWorkletEffect'
-import makeKelvinLinearRGB from '../utilities/makeKelvinLinearRGB'
+import convertKelvinToLinearSRGB from '../utilities/convertKelvinToLinearSRGB'
 
 export type UseLightEntityProps =
   | LightConfig
@@ -89,7 +89,7 @@ export function useLightEntity(lightManager: LightManager, config: UseLightEntit
     return colorKelvin.addListener(
       workletContext.createRunAsync(() => {
         'worklet'
-        setColor(entity, makeKelvinLinearRGB(colorKelvin.value))
+        setColor(entity, convertKelvinToLinearSRGB(colorKelvin.value))
       })
     )
   })

--- a/package/src/hooks/useLightEntity.ts
+++ b/package/src/hooks/useLightEntity.ts
@@ -3,11 +3,13 @@ import { LightConfig, LightManager } from '../types'
 import { ISharedValue } from 'react-native-worklets-core'
 import { useFilamentContext } from './useFilamentContext'
 import { useWorkletEffect } from './useWorkletEffect'
+import makeKelvinLinearRGB from '../utilities/makeKelvinLinearRGB'
 
 export type UseLightEntityProps =
   | LightConfig
-  | (Omit<LightConfig, 'intensity'> & {
-      intensity?: ISharedValue<number>
+  | (Omit<LightConfig, 'intensity' | 'colorKelvin'> & {
+      intensity?: number | ISharedValue<number>
+      colorKelvin?: number | ISharedValue<number>
     })
 
 /**
@@ -32,7 +34,7 @@ export function useLightEntity(lightManager: LightManager, config: UseLightEntit
   const entity = useMemo(() => {
     return lightManager.createLightEntity(
       config.type,
-      config.colorKelvin,
+      typeof config.colorKelvin === 'number' ? config.colorKelvin : config.colorKelvin?.value,
       typeof config.intensity === 'number' ? config.intensity : config.intensity?.value,
       directionX != null && directionY != null && directionZ != null ? [directionX, directionY, directionZ] : undefined,
       positionX != null && positionY != null && positionZ != null ? [positionX, positionY, positionZ] : undefined,
@@ -57,7 +59,7 @@ export function useLightEntity(lightManager: LightManager, config: UseLightEntit
     positionZ,
   ])
 
-  // Eventually subscribe to the intensity shared value
+  // Subscribe to the intensity shared value
   const { workletContext } = useFilamentContext()
   useWorkletEffect(() => {
     'worklet'
@@ -71,6 +73,23 @@ export function useLightEntity(lightManager: LightManager, config: UseLightEntit
       workletContext.createRunAsync(() => {
         'worklet'
         setIntensity(entity, intensity.value)
+      })
+    )
+  })
+
+  // Subscribe to the colorKelvin shared value
+  useWorkletEffect(() => {
+    'worklet'
+    const colorKelvin = config.colorKelvin
+    if (colorKelvin == null) return
+    if (typeof colorKelvin === 'number') return
+
+    const setColor = lightManager.setColor
+
+    return colorKelvin.addListener(
+      workletContext.createRunAsync(() => {
+        'worklet'
+        setColor(entity, makeKelvinLinearRGB(colorKelvin.value))
       })
     )
   })

--- a/package/src/types/LightManager.ts
+++ b/package/src/types/LightManager.ts
@@ -52,11 +52,11 @@ export interface LightManager extends PointerHolder {
    * @param color Color of the light specified in the linear sRGB color-space.
    *              The default is white {1,1,1}.
    */
-  setColor(entityWrapper: Entity, linearSRGBColor: Float3[]): void
+  setColor(entityWrapper: Entity, linearSRGBColor: Float3): void
   /**
    * Returns the light's color in linear sRGB color-space.
    */
-  getColor(entityWrapper: Entity): Float3[]
+  getColor(entityWrapper: Entity): Float3
   /**
    * Dynamically updates the light's intensity. The intensity can be negative.
    *

--- a/package/src/utilities/convertKelvinToLinearSRGB.ts
+++ b/package/src/utilities/convertKelvinToLinearSRGB.ts
@@ -1,4 +1,4 @@
-type Float3 = [number, number, number]
+import { Float3 } from '../types'
 
 // Converts sRGB to linear light
 function toLinear(c: number): number {
@@ -7,7 +7,7 @@ function toLinear(c: number): number {
 }
 
 // Converts a Kelvin temp to linear sRGB color
-export default function makeKelvinLinearRGB(kelvin: number): Float3[] {
+export default function convertKelvinToLinearSRGB(kelvin: number): Float3 {
   'worklet'
 
   const temp = kelvin / 100

--- a/package/src/utilities/makeKelvinLinearRGB.ts
+++ b/package/src/utilities/makeKelvinLinearRGB.ts
@@ -1,0 +1,37 @@
+type Float3 = [number, number, number]
+
+// Converts sRGB to linear light
+function toLinear(c: number): number {
+  'worklet'
+  return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+}
+
+// Converts a Kelvin temp to linear sRGB color
+export default function makeKelvinLinearRGB(kelvin: number): Float3[] {
+  'worklet'
+
+  const temp = kelvin / 100
+  let red: number, green: number, blue: number
+
+  if (temp <= 66) {
+    red = 255
+    green = temp < 19 ? 0 : 99.4708025861 * Math.log(temp - 10) - 161.1195681661
+  } else {
+    red = 329.698727446 * (temp - 60) ** -0.1332047592
+    green = 288.1221695283 * (temp - 60) ** -0.0755148492
+  }
+
+  if (temp >= 66) {
+    blue = 255
+  } else if (temp <= 19) {
+    blue = 0
+  } else {
+    blue = 138.5177312231 * Math.log(temp - 10) - 305.0447927307
+  }
+
+  const r = toLinear(Math.max(0, Math.min(255, red)) / 255)
+  const g = toLinear(Math.max(0, Math.min(255, green)) / 255)
+  const b = toLinear(Math.max(0, Math.min(255, blue)) / 255)
+
+  return [r, g, b]
+}


### PR DESCRIPTION
## Description

Allows `colorKelvin` to receive a `ISharedValue<number>` so we can animate it with shared values.

Depends on #314

## Features 
- Animated Light's `colorKelvin` prop via shared values (from `react-native-worklets-core`)
- `convertKelvinToLinearSRGB` helper function to convert Kelvin temperature value to linear sRGB

## Showcase

<video src="https://github.com/user-attachments/assets/5acc1468-4b45-426f-97ac-25db478abfad" />

