### PR TITLE
feat: expose orthographic camera projection

### DIFF
--- a/package/cpp/core/RNFCameraWrapper.cpp
+++ b/package/cpp/core/RNFCameraWrapper.cpp
@@ -6,6 +6,7 @@ void margelo::CameraWrapper::loadHybridMethods() {
   registerHybridMethod("lookAt", &CameraWrapper::lookAt, this);
   registerHybridMethod("setLensProjection", &CameraWrapper::setLensProjection, this);
   registerHybridMethod("setProjection", &CameraWrapper::setProjection, this);
+  registerHybridMethod("setOrthographicProjection", &CameraWrapper::setOrthographicProjection, this);
 }
 
 void margelo::CameraWrapper::lookAtCameraManipulator(std::shared_ptr<ManipulatorWrapper> cameraManipulator) {
@@ -36,4 +37,8 @@ void margelo::CameraWrapper::setProjection(double fovInDegrees, double aspect, d
 
   pointee()->setProjection(static_cast<float>(fovInDegrees), static_cast<float>(aspect), static_cast<float>(near), static_cast<float>(far),
                            direction);
+}
+
+void margelo::CameraWrapper::setOrthographicProjection(double left, double right, double bottom, double top, double near, double far) {
+  pointee()->setProjection(Camera::Projection::ORTHO, left, right, bottom, top, near, far);
 }

--- a/package/cpp/core/RNFCameraWrapper.h
+++ b/package/cpp/core/RNFCameraWrapper.h
@@ -18,6 +18,7 @@ private:
   void lookAt(std::vector<double> eye, std::vector<double> center, std::vector<double> up);
   void setLensProjection(double fov, double aspect, double near, double far);
   void setProjection(double fovInDegrees, double aspect, double near, double far, std::string directionStr);
+  void setOrthographicProjection(double left, double right, double bottom, double top, double near, double far);
   // Convenience methods
   void lookAtCameraManipulator(std::shared_ptr<ManipulatorWrapper> cameraManipulator);
 };

--- a/package/src/types/Camera.ts
+++ b/package/src/types/Camera.ts
@@ -98,4 +98,16 @@ export interface RNFCamera extends PointerHolder {
    * @see Fov.
    */
   setProjection(fov: number, aspect: number, near: number, far: number): void
+
+  /**
+   * Sets an orthographic projection matrix from six clip planes.
+   *
+   * @param left   distance in world units from the camera to the left plane.
+   * @param right  distance in world units from the camera to the right plane.
+   * @param bottom distance in world units from the camera to the bottom plane.
+   * @param top    distance in world units from the camera to the top plane.
+   * @param near   distance in world units from the camera to the near plane. near != far.
+   * @param far    distance in world units from the camera to the far plane. far != near.
+   */
+  setOrthographicProjection(left: number, right: number, bottom: number, top: number, near: number, far: number): void
 }


### PR DESCRIPTION
## Description

Filament already supports orthographic cameras through `Camera::setProjection(Camera::Projection::ORTHO, ...)`, but react-native-filament currently only exposes the perspective helpers through the JS camera wrapper.

This PR bridges that existing Filament API so React Native callers can configure an orthographic projection without dropping down to native code.

## Changes

- Adds `camera.setOrthographicProjection(left, right, bottom, top, near, far)` to the native Camera wrapper.
- Registers the new method with the JSI hybrid object.
- Adds the method to the `RNFCamera` TypeScript interface.

## Testing

- Ran `yarn check-all` from `package/`.
- Verified C++ formatting ran after installing the missing `clang-format` local dependency.
- Verified ESLint and TypeScript completed successfully.
