### PR TITLE
fix: crash on scene teardown after changeMaterialTextureMap (MaterialInstance destroyed while attached)

### DIFF
--- a/examples/Shared/src/ChangeMaterials.tsx
+++ b/examples/Shared/src/ChangeMaterials.tsx
@@ -9,7 +9,11 @@ import RocketGlb from '@assets/rocket.glb'
 const baseColorBlueImage = require('@assets/rocket_BaseColor_Blue.png')
 
 function Renderer() {
-  const [showBlue, setShowBlue] = React.useState(false)
+  // Regression test for a crash on scene teardown: after changing a texture map, navigating back
+  // from this screen must not abort with filament's "destroying MaterialInstance which is still
+  // in use by Renderable" precondition. Every press re-applies the texture map, which also
+  // exercises destroying the superseded material instance and texture of a slot.
+  const [applyCount, setApplyCount] = React.useState(0)
   const blueBaseColorBuffer = useBuffer({ source: baseColorBlueImage })
   const materialName = 'Toy Ship'
 
@@ -20,18 +24,18 @@ function Renderer() {
         <DefaultLight />
 
         <Model source={RocketGlb} translate={[0, -1, 0]}>
-          {blueBaseColorBuffer != null && showBlue && (
-            <>
+          {blueBaseColorBuffer != null && applyCount > 0 && (
+            <React.Fragment key={applyCount}>
               <EntitySelector byName="Tip" textureMap={{ materialName, textureSource: blueBaseColorBuffer }} />
               <EntitySelector byName="Wings" textureMap={{ materialName, textureSource: blueBaseColorBuffer }} />
-            </>
+            </React.Fragment>
           )}
         </Model>
       </FilamentView>
       <Button
         title="Change Color"
         onPress={() => {
-          setShowBlue(true)
+          setApplyCount((count) => count + 1)
         }}
       />
     </SafeAreaView>

--- a/package/cpp/core/RNFRenderableManagerImpl.cpp
+++ b/package/cpp/core/RNFRenderableManagerImpl.cpp
@@ -137,22 +137,66 @@ void RenderableManagerImpl::changeMaterialTextureMap(std::shared_ptr<EntityWrapp
   // This material instance still belongs to the original asset and will be cleaned up when the asset is destroyed
   MaterialInstance* materialInstance = renderableManager.getMaterialInstanceAt(instance, primitiveIndex);
 
+  std::pair<uint32_t, size_t> slotKey = {entityInstance.getId(), primitiveIndex};
+
+  // Remember the asset-owned instance that was attached before our first replacement on this slot.
+  // The deleter below restores it if the duplicate is destroyed while still attached (teardown),
+  // so the renderable never references a destroyed instance and the duplicate can be destroyed
+  // without hitting filament's "still in use by Renderable" precondition. The original is only
+  // touched when the entity still exists, which implies the asset (its owner) is still alive.
+  MaterialInstance* originalInstance;
+  auto originalIt = _slotOriginalInstances.find(slotKey);
+  if (originalIt == _slotOriginalInstances.end()) {
+    originalInstance = materialInstance;
+    _slotOriginalInstances[slotKey] = originalInstance;
+  } else {
+    originalInstance = originalIt->second;
+  }
+
   // The texture might not be loaded yet, but we can already set it on the material instance
   auto engine = _engine;
   auto dispatcher = _rendererDispatcher;
+  Entity slotEntity = entityInstance;
+  size_t slotIndex = primitiveIndex;
   std::shared_ptr<MaterialInstance> newInstance =
-      std::shared_ptr<MaterialInstance>(MaterialInstance::duplicate(materialInstance), [engine, dispatcher](MaterialInstance* instance) {
-        dispatcher->runAsync([engine, instance]() {
-          Logger::log(TAG, "Destroying material instance %p", instance);
-          engine->destroy(instance);
-        });
-      });
+      std::shared_ptr<MaterialInstance>(MaterialInstance::duplicate(materialInstance),
+                                        [engine, dispatcher, slotEntity, slotIndex, originalInstance](MaterialInstance* instance) {
+                                          dispatcher->runAsync([engine, slotEntity, slotIndex, originalInstance, instance]() {
+                                            RenderableManager& renderableManager = engine->getRenderableManager();
+                                            if (renderableManager.hasComponent(slotEntity)) {
+                                              RenderableManager::Instance renderable = renderableManager.getInstance(slotEntity);
+                                              if (slotIndex < renderableManager.getPrimitiveCount(renderable) &&
+                                                  renderableManager.getMaterialInstanceAt(renderable, slotIndex) == instance) {
+                                                // Still attached (teardown path) — detach by restoring the asset's original instance.
+                                                // Destroying an attached instance, or letting the material provider destroy the parent
+                                                // material while duplicates are alive, is a fatal precondition in filament.
+                                                Logger::log(TAG, "Restoring original material instance on entity before destroy");
+                                                renderableManager.setMaterialInstanceAt(renderable, slotIndex, originalInstance);
+                                              }
+                                            }
+                                            Logger::log(TAG, "Destroying material instance %p", instance);
+                                            engine->destroy(instance);
+                                          });
+                                        });
 
   auto sampler = TextureSampler(TextureSampler::MinFilter::LINEAR, TextureSampler::MagFilter::LINEAR, TextureSampler::WrapMode::REPEAT);
   Texture* texture = createTextureFromBuffer(textureBuffer, textureFlags);
   newInstance->setParameter("baseColorMap", texture, sampler);
   renderableManager.setMaterialInstanceAt(instance, primitiveIndex, newInstance.get());
-  _materialInstances.push_back(newInstance);
+
+  // Replacing the slot entry releases the superseded instance — it is detached now (the renderable
+  // points at newInstance), so its deleter can safely destroy it.
+  _slotMaterialInstances[slotKey] = newInstance;
+  // The superseded texture is no longer sampled by any attached instance; destroy it.
+  auto previousTexture = _slotTextures.find(slotKey);
+  if (previousTexture != _slotTextures.end()) {
+    Texture* oldTexture = previousTexture->second;
+    dispatcher->runAsync([engine, oldTexture]() {
+      Logger::log(TAG, "Destroying texture %p", oldTexture);
+      engine->destroy(oldTexture);
+    });
+  }
+  _slotTextures[slotKey] = texture;
 
   // Load the texture
   startUpdateResourceLoading();

--- a/package/cpp/core/RNFRenderableManagerImpl.h
+++ b/package/cpp/core/RNFRenderableManagerImpl.h
@@ -15,6 +15,9 @@
 #include <filament/RenderableManager.h>
 #include <gltfio/TextureProvider.h>
 
+#include <map>
+#include <utility>
+
 namespace margelo {
 using namespace filament;
 using namespace gltfio;
@@ -91,8 +94,17 @@ private:
   std::shared_ptr<Engine> _engine;
   std::shared_ptr<Dispatcher> _rendererDispatcher;
   std::shared_ptr<TextureProvider> _textureProvider;
-  // Keep a list of all material instances the RenderableManager creates, so we can clean them up when the RenderableManager is
-  std::vector<std::shared_ptr<MaterialInstance>> _materialInstances;
+  // Material instances created by changeMaterialTextureMap, keyed by (entity id, primitive index).
+  // Only the latest instance per slot is attached to the renderable; replacing a slot entry
+  // releases the superseded (now detached) instance, whose deleter destroys it. At manager
+  // teardown the deleter detaches a still-attached instance first (restoring the slot's original
+  // asset-owned instance) — see changeMaterialTextureMap.
+  std::map<std::pair<uint32_t, size_t>, std::shared_ptr<MaterialInstance>> _slotMaterialInstances;
+  // The asset-owned instance each slot had before our first replacement (restore target on teardown).
+  std::map<std::pair<uint32_t, size_t>, MaterialInstance*> _slotOriginalInstances;
+  // Textures created by changeMaterialTextureMap, keyed the same way. A superseded texture is no
+  // longer sampled by the replacement instance and is destroyed eagerly (previously these leaked).
+  std::map<std::pair<uint32_t, size_t>, Texture*> _slotTextures;
   std::vector<std::unique_ptr<DebugVertex[]>> _debugVerticesList;
 
 private:


### PR DESCRIPTION
# What

Fixes a fatal abort (SIGABRT) on scene teardown after `RenderableManager.changeMaterialTextureMap()` has been used, and fixes a permanent GPU memory leak of the `Texture` created per call (plausibly a contributor to #297). The teardown crash is the same class of teardown-order problem as #130.

Affects 1.11.0 (shared C++, so both Android and iOS). The bug class exists in earlier versions too, but the filament core bundled with 1.11.0 turned it from a silent leak into a fatal precondition abort.

# The bug

`changeMaterialTextureMap()` duplicates the entity's current `MaterialInstance`, binds the duplicate via `setMaterialInstanceAt`, and accumulates every duplicate in `_materialInstances`, which is only released when `RenderableManagerImpl` is destroyed. The `Texture*` created per call is never destroyed at all.

At scene teardown the JS wrappers release in nondeterministic order (`withCleanupScope` defers releases through `InteractionManager` + `setTimeout`). When `RenderableManagerWrapper` releases before `FilamentAssetWrapper`, the duplicate instance is destroyed while still attached to the renderable, and filament aborts:

```
Filament: Precondition in destroy:1308
reason: destroying MaterialInstance "Screen" which is still in use by Renderable (entity=6, instance=2, index=0)
Fatal signal 6 (SIGABRT) in tid ... (FilamentRendere)
```

Simply *skipping* the destroy at teardown is not a fix — it trips filament's other precondition when gltfio's ubershader material provider destroys the parent `Material` during scene destruction (tested, verified in crash logs):

```
Filament: Precondition in terminate:220
reason: destroying material "base_lit_fade" but 2 instances still alive.
```

So the duplicates must genuinely be destroyed before `destroyMaterials()` runs, but never while attached.

## Repro

1. Render a `<FilamentScene>` + `<FilamentView>` + `<ModelRenderer>` with any GLB.
2. Call `renderableManager.changeMaterialTextureMap(entity, materialName, buffer, 'sRGB')` at least once (e.g. via `<EntitySelector textureMap={...}>`).
3. Unmount the scene (navigate away).
4. App aborts on the `FilamentRendere` thread.

The `🎨 Change Materials` example screen reproduces this: press "Change Color", then navigate back. It crashes before this fix and tears down cleanly after (logging `Restoring original material instance...` / `Destroying material instance...`).

# The fix

Two parts, both in `RNFRenderableManagerImpl.{h,cpp}`:

1. **Detach-then-destroy deleter.** The duplicate's `shared_ptr` deleter dispatches to the renderer thread and, if the instance is *still attached* to the renderable (teardown path), first restores the slot's **original asset-owned `MaterialInstance`**, then destroys the duplicate. This satisfies both preconditions and is safe in any teardown order:
   - Entity still alive → asset (owner of the original) is necessarily alive → restore original, destroy duplicate.
   - Asset already destroyed → `hasComponent(entity)` is false → destroy duplicate directly.
   - Runtime texture replacement → the renderable already points at the newer duplicate → destroy directly.

   All destruction work runs on the single renderer dispatcher (FIFO), so the destroys land before the scene deleter runs `materialProvider->destroyMaterials()`.

2. **Per-slot tracking replaces the grow-forever vector.** Keyed by `(entity id, primitive index)`:
   - `_slotMaterialInstances` — holds only the currently-attached duplicate per slot; replacing the entry releases (→ destroys) the superseded one.
   - `_slotOriginalInstances` — the asset-owned instance each slot had before the first replacement (the restore target).
   - `_slotTextures` — textures created per slot; a superseded texture is destroyed eagerly (fixes the permanent leak).

# Verification

- Compiles clean for arm64-v8a, armeabi-v7a, and x86 via the module's `externalNativeBuildDebug` (NDK/CMake).
- Crash reproduced and fix verified on an Android 16 arm64 emulator inside a production app (repeated texture applies + orientation changes, then unmount — teardown completes with the restore/destroy log lines and no filament precondition). This exact change has been shipping in that app via patch-package.
- iOS untested, but the fix is in shared C++ compiled by both platforms.
- The `🎨 Change Materials` example screen was extended to serve as the regression repro: every press now re-applies the texture map (exercising the superseded-instance/texture destroy path), and navigating back exercises the teardown path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
